### PR TITLE
Ontology management changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,19 +37,20 @@ setup(
             "Remote = simphony_osp.interfaces.remote:Remote",
         },
         "console_scripts": {
-            "pico = simphony_osp.utils.pico:pico",
+            "pico = simphony_osp.tools.pico:terminal",
             "semantic2dot = simphony_osp.tools.semantic2dot"
             ":run_from_terminal",
         },
     },
     install_requires=[
-        "PyYaml",
-        "websockets < 10",
-        "requests",
-        "numpy",
         "graphviz",
+        "numpy",
+        "PyYaml",
         "rdflib >= 6.0.2, < 7.0.0",
         "rdflib-sqlalchemy >= 0.5.0",
+        "requests",
+        "websockets < 11",
+        "websockets >= 10; python_version >= '3.10'",
     ],
     setup_requires=[],
 )

--- a/simphony_osp/__init__.py
+++ b/simphony_osp/__init__.py
@@ -1,1 +1,5 @@
 """SimPhoNy OSP module."""
+
+from importlib import import_module as _import_module
+
+_import_module('simphony_osp.utils.pico')  # Load installed ontologies

--- a/simphony_osp/__init__.py
+++ b/simphony_osp/__init__.py
@@ -2,4 +2,4 @@
 
 from importlib import import_module as _import_module
 
-_import_module('simphony_osp.utils.pico')  # Load installed ontologies
+_import_module("simphony_osp.utils.pico")  # Load installed ontologies

--- a/simphony_osp/namespaces.py
+++ b/simphony_osp/namespaces.py
@@ -22,13 +22,13 @@ _logger = _logging.getLogger(__name__)
 
 def __getattr__(name: str):
     try:
-        return _Session.ontology.get_namespace(name)
+        return _Session.default_ontology.get_namespace(name)
     except KeyError as e:
         raise AttributeError from e
 
 
 def __dir__():
-    return list((x.name for x in _Session.ontology.namespaces))
+    return list((x.name for x in _Session.default_ontology.namespaces))
 
 
 __all__ = __dir__()
@@ -51,7 +51,7 @@ def from_iri(iri: _Union[str, _URIRef]):
         iri = _URIRef(iri)
     if not isinstance(iri, _URIRef):
         raise TypeError(f"Expected {str} or {_URIRef}, not {type(iri)}.")
-    return _Session.ontology.from_identifier(iri)
+    return _Session.default_ontology.from_identifier(iri)
 
 
 # `from_identifier` as gateway to `_tbox.from_identifier`.
@@ -67,4 +67,4 @@ def from_identifier(identifier: _Identifier) -> "OntologyEntity":
     Returns:
         The OntologyEntity.
     """
-    return _Session.ontology.from_identifier(identifier)
+    return _Session.default_ontology.from_identifier(identifier)

--- a/simphony_osp/namespaces.py
+++ b/simphony_osp/namespaces.py
@@ -8,9 +8,6 @@ from rdflib import URIRef as _URIRef
 from rdflib.term import Identifier as _Identifier
 
 from simphony_osp.session.session import Session as _Session
-from simphony_osp.utils.pico import (
-    OntologyInstallationManager as _OntologyInstallationManager,
-)
 
 if _TYPE_CHECKING:
     from simphony_osp.ontology.entity import OntologyEntity
@@ -18,22 +15,6 @@ if _TYPE_CHECKING:
 self = __import__(__name__)
 
 _logger = _logging.getLogger(__name__)
-
-# --- Load installed ontologies --
-# Set ontology directory and create it if nonexistent
-
-# Load the ontologies.
-_default_ontology = _Session.ontology
-try:
-    # Sort installed ontologies for loading (topological sort).
-    _InstallationManager = _OntologyInstallationManager()
-    _parsers = _InstallationManager.topologically_sorted_parsers
-
-    # Load installed ontologies.
-    for _parser in _parsers:
-        _default_ontology.load_parser(_parser)
-except RuntimeError:
-    _logger.critical("Could not load installed ontologies.", exc_info=1)
 
 
 # Access namespaces from this module.
@@ -67,7 +48,7 @@ def from_iri(iri: _Union[str, _URIRef]):
         The OntologyEntity.
     """
     if type(iri) is str:
-        iri = _URIRef(str)
+        iri = _URIRef(iri)
     if not isinstance(iri, _URIRef):
         raise TypeError(f"Expected {str} or {_URIRef}, not {type(iri)}.")
     return _Session.ontology.from_identifier(iri)

--- a/simphony_osp/ontology/files/city.yml
+++ b/simphony_osp/ontology/files/city.yml
@@ -1,9 +1,5 @@
 identifier: city
 ontology_file: city.ttl
 format: 'turtle'
-reference_by_label: False
 namespaces:
     city: https://www.simphony-project.eu/city#
-active_relationships:
-    - https://www.simphony-project.eu/city#encloses
-default_relationship: https://www.simphony-project.eu/city#hasPart

--- a/simphony_osp/ontology/files/dcam.yml
+++ b/simphony_osp/ontology/files/dcam.yml
@@ -1,7 +1,5 @@
 ---
 identifier: dcam
 ontology_file: https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_abstract_model.rdf
-reference_by_label: False
 namespaces:
     dcam: http://purl.org/dc/dcam/
-active_relationships: []

--- a/simphony_osp/ontology/files/dcat2.yml
+++ b/simphony_osp/ontology/files/dcat2.yml
@@ -1,7 +1,8 @@
----
 identifier: dcat2
 ontology_file: https://www.w3.org/ns/dcat2.rdf
-reference_by_label: False
+requirements:
+    - dcterms
+    - prov
+    - foaf
 namespaces:
     dcat2: http://www.w3.org/ns/dcat#
-active_relationships: []

--- a/simphony_osp/ontology/files/dcelements.yml
+++ b/simphony_osp/ontology/files/dcelements.yml
@@ -1,7 +1,5 @@
 ---
 identifier: dcelements
 ontology_file: https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_elements.rdf
-reference_by_label: False
 namespaces:
     dcelements: http://purl.org/dc/elements/1.1/
-active_relationships: []

--- a/simphony_osp/ontology/files/dcmitype.yml
+++ b/simphony_osp/ontology/files/dcmitype.yml
@@ -1,0 +1,4 @@
+identifier: dcmitype
+ontology_file: https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_type.ttl
+namespaces:
+    dcmitype: "http://purl.org/dc/dcmitype/"

--- a/simphony_osp/ontology/files/dcterms.yml
+++ b/simphony_osp/ontology/files/dcterms.yml
@@ -1,10 +1,6 @@
----
 identifier: dcterms
-ontology_file: https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_terms.rdf
-reference_by_label: False
-namespaces:
-    dcterms: http://purl.org/dc/terms/
-active_relationships: []
+ontology_file: https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_terms.ttl
 requirements:
-  - dctype
-  - dcelements
+    - dcmitype
+namespaces:
+    dcterms: "http://purl.org/dc/terms/"

--- a/simphony_osp/ontology/files/dctype.yml
+++ b/simphony_osp/ontology/files/dctype.yml
@@ -1,7 +1,0 @@
----
-identifier: dctype
-ontology_file: https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_type.rdf
-reference_by_label: False
-namespaces:
-    dctype: http://purl.org/dc/dcmitype/
-active_relationships: []

--- a/simphony_osp/ontology/files/emmo-datamodel.yml
+++ b/simphony_osp/ontology/files/emmo-datamodel.yml
@@ -1,0 +1,4 @@
+identifier: emmo-datamodel
+ontology_file: https://emmo-repo.github.io/datamodel-ontology/versions/0.0.2/metamodel-inferred.ttl
+namespaces:
+    datamodel: http://emmo.info/datamodel#

--- a/simphony_osp/ontology/files/emmo.yml
+++ b/simphony_osp/ontology/files/emmo.yml
@@ -1,26 +1,4 @@
----
 identifier: emmo
-ontology_file: https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-alpha2/emmo-inferred.owl
-reference_by_label: True
+ontology_file: https://emmo-repo.github.io/versions/1.0.0-beta4/emmo-inferred.ttl
 namespaces:
-    annotations: http://emmo.info/emmo/top/annotations
-    mereotopology: http://emmo.info/emmo/top/mereotopology
-    physical: http://emmo.info/emmo/top/physical
-    top: http://emmo.info/emmo/top
-    semiotics: http://emmo.info/emmo/middle/semiotics
-    perceptual: http://emmo.info/emmo/middle/perceptual
-    reductionistic: http://emmo.info/emmo/middle/reductionistic
-    holistic: http://emmo.info/emmo/middle/holistic
-    physicalistic: http://emmo.info/emmo/middle/physicalistic
-    math: http://emmo.info/emmo/middle/math
-    properties: http://emmo.info/emmo/middle/properties
-    materials: http://emmo.info/emmo/middle/materials
-    metrology: http://emmo.info/emmo/middle/metrology
-    models: http://emmo.info/emmo/middle/models
-    manufacturing: http://emmo.info/emmo/middle/manufacturing
-    isq: http://emmo.info/emmo/middle/isq
-    siunits: http://emmo.info/emmo/middle/siunits
-active_relationships:
-    - http://emmo.info/emmo/top/mereotopology#EMMO_8c898653_1118_4682_9bbf_6cc334d16a99
-    - http://emmo.info/emmo/middle/semiotics#EMMO_60577dea_9019_4537_ac41_80b0fb563d41
-default_relationship: http://emmo.info/emmo/top/mereotopology#EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f
+    emmo: http://emmo.info/emmo

--- a/simphony_osp/ontology/files/foaf.yml
+++ b/simphony_osp/ontology/files/foaf.yml
@@ -1,7 +1,4 @@
----
 identifier: foaf
 ontology_file: http://xmlns.com/foaf/spec/index.rdf
-reference_by_label: False
 namespaces:
     foaf: "http://xmlns.com/foaf/0.1/"
-active_relationships: []

--- a/simphony_osp/ontology/files/owl.yml
+++ b/simphony_osp/ontology/files/owl.yml
@@ -1,8 +1,5 @@
 identifier: owl
 ontology_file: owl.ttl
 format: 'turtle'
-reference_by_label: False
 namespaces:
     owl: http://www.w3.org/2002/07/owl#
-active_relationships: []
-default_relationship: http://www.w3.org/2002/07/owl#topObjectProperty

--- a/simphony_osp/ontology/files/prov.yml
+++ b/simphony_osp/ontology/files/prov.yml
@@ -1,0 +1,5 @@
+identifier: prov
+ontology_file: http://www.w3.org/ns/prov-o
+format: ttl
+namespaces:
+    prov: http://www.w3.org/ns/prov#

--- a/simphony_osp/ontology/files/rdfs.yml
+++ b/simphony_osp/ontology/files/rdfs.yml
@@ -1,7 +1,5 @@
 identifier: rdfs
 ontology_file: rdfs.ttl
 format: 'turtle'
-reference_by_label: False
 namespaces:
     rdfs: http://www.w3.org/2000/01/rdf-schema#
-active_relationships: []

--- a/simphony_osp/ontology/files/simphony.ttl
+++ b/simphony_osp/ontology/files/simphony.ttl
@@ -13,84 +13,11 @@
 #    Annotation properties
 #################################################################
 
-###  https://www.simphony-project.eu/simphony#_default
-simphony:_default rdf:type owl:AnnotationProperty .
-
-
-###  https://www.simphony-project.eu/simphony#_default_attribute
-simphony:_default_attribute rdf:type owl:AnnotationProperty .
-
-
-###  https://www.simphony-project.eu/simphony#_default_rel
-simphony:_default_rel rdf:type owl:AnnotationProperty .
-
-
-###  https://www.simphony-project.eu/simphony#_default_value
-simphony:_default_value rdf:type owl:AnnotationProperty .
-
-
-###  https://www.simphony-project.eu/simphony#_reference_by_label
-simphony:_reference_by_label rdf:type owl:AnnotationProperty .
-
-
 ###  https://www.simphony-project.eu/simphony#main
 simphony:main rdf:type owl:AnnotationProperty ;
               rdfs:comment "When multiple ontology individuals are serialized to a file, one of them can be tagged with this proverty (whose value must be True). When the file is imported again in SimPhoNy, only such item will be returned."@en ;
               rdfs:label "Main individual"@en ;
               rdfs:range xsd:boolean .
-
-
-#################################################################
-#    Object Properties
-#################################################################
-
-###  https://www.simphony-project.eu/simphony#activeRelationship
-simphony:activeRelationship rdf:type owl:ObjectProperty ;
-                            rdfs:subPropertyOf simphony:relationship ;
-                            owl:inverseOf simphony:passiveRelationship ;
-                            rdfs:isDefinedBy "The root of all active relationships. Active relationships express that one ontology individual contains another ontology individual."@en .
-
-
-###  https://www.simphony-project.eu/simphony#contains
-simphony:contains rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf simphony:activeRelationship ;
-                  rdf:type owl:IrreflexiveProperty ;
-                  rdfs:domain simphony:Container ;
-                  rdfs:comment "Containment relationship for the 'Container' class."@en .
-
-
-###  https://www.simphony-project.eu/simphony#passiveRelationship
-simphony:passiveRelationship rdf:type owl:ObjectProperty ;
-                             rdfs:subPropertyOf simphony:relationship ;
-                             rdfs:isDefinedBy "The inverse of activeRelationship. Passive relationships express that one ontology individual is contained in another ontology individual."@en .
-
-
-###  https://www.simphony-project.eu/simphony#relationship
-simphony:relationship rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf owl:topObjectProperty ;
-                      owl:inverseOf simphony:relationship ;
-                      rdf:type owl:SymmetricProperty ;
-                      rdfs:isDefinedBy "The root of all relationships." .
-
-
-#################################################################
-#    Data properties
-#################################################################
-
-###  https://www.simphony-project.eu/simphony#attribute
-simphony:attribute rdf:type owl:DatatypeProperty ;
-                   rdfs:subPropertyOf owl:topDataProperty ;
-                   rdf:type owl:FunctionalProperty ;
-                   rdfs:isDefinedBy "The root of all attributes." .
-
-
-###  https://www.simphony-project.eu/simphony#path
-simphony:path rdf:type owl:DatatypeProperty ;
-              rdfs:subPropertyOf simphony:attribute ;
-              rdf:type owl:FunctionalProperty ;
-              rdfs:domain simphony:File ;
-              rdfs:range xsd:string ;
-              rdfs:isDefinedBy "The path to a local file." .
 
 
 #################################################################

--- a/simphony_osp/ontology/files/simphony.ttl
+++ b/simphony_osp/ontology/files/simphony.ttl
@@ -19,6 +19,11 @@ simphony:main rdf:type owl:AnnotationProperty ;
               rdfs:label "Main individual"@en ;
               rdfs:range xsd:boolean .
 
+###  https://www.simphony-project.eu/simphony#contains
+simphony:contains rdf:type owl:ObjectProperty ;
+                  rdf:type owl:IrreflexiveProperty ;
+                  rdfs:domain simphony:Container ;
+                  rdfs:comment "Containment relationship for the 'Container' class."@en .
 
 #################################################################
 #    Classes

--- a/simphony_osp/ontology/files/simphony.yml
+++ b/simphony_osp/ontology/files/simphony.yml
@@ -1,8 +1,5 @@
 identifier: simphony
 ontology_file: simphony.ttl
 format: 'turtle'
-reference_by_label: False
 namespaces:
     simphony: https://www.simphony-project.eu/simphony#
-active_relationships:
-    - https://www.simphony-project.eu/simphony#activeRelationship

--- a/simphony_osp/ontology/individual.py
+++ b/simphony_osp/ontology/individual.py
@@ -517,10 +517,10 @@ class RelationshipSet(ObjectSet):
             if rel not in allowed:
                 raise RuntimeError(
                     f"Predicate {rel} not within the set of allowed "
-                    f"predicates {allowed}"
+                    f"predicates {allowed}."
                 )
         if rel is None:
-            raise RuntimeError(f"No predicate specified.")
+            raise RuntimeError("No predicate specified.")
         rel = rel.identifier
 
         for individual in individuals:
@@ -564,7 +564,7 @@ class RelationshipSet(ObjectSet):
                     f"predicates {allowed}"
                 )
         if rel is None:
-            raise RuntimeError(f"No predicate specified.")
+            raise RuntimeError("No predicate specified.")
 
         for rel in rel.subclasses:
             for individual in individuals:

--- a/simphony_osp/ontology/individual.py
+++ b/simphony_osp/ontology/individual.py
@@ -100,7 +100,7 @@ class ObjectSet(DataStructureSet, ABC):
         return self._individual
 
     @property
-    def predicate(self) -> Union[OntologyPredicate]:
+    def predicate(self) -> OntologyPredicate:
         """Predicate that this set refers to."""
         return self._predicate
 
@@ -441,9 +441,7 @@ class RelationshipSet(ObjectSet):
         # TODO: We do not take care of 3, because `.add` also does not
         #  take care of 3. This topic can be an object of discussion.
         for individual in added:
-            self._individual.relationships_connect(
-                individual, rel=self._predicate
-            )
+            self._connect(individual, rel=self._predicate)
 
     @prevent_class_filtering
     def intersection_update(self, other: Iterable[OntologyIndividual]) -> None:
@@ -455,10 +453,10 @@ class RelationshipSet(ObjectSet):
         removed = underlying_set.difference(result)
         if removed:
             for rel in self._predicates:
-                self._individual.relationships_disconnect(*removed, rel=rel)
+                self._disconnect(*removed, rel=rel)
 
         added = result.difference(underlying_set)
-        self._individual.relationships_connect(*added, rel=self._predicate)
+        self._connect(*added, rel=self._predicate)
 
     @prevent_class_filtering
     def difference_update(self, other: Iterable[OntologyIndividual]) -> None:
@@ -467,7 +465,7 @@ class RelationshipSet(ObjectSet):
         removed = set(self) & set(other)
         if removed:
             for rel in self._predicates:
-                self._individual.relationships_disconnect(*removed, rel=rel)
+                self._disconnect(*removed, rel=rel)
 
     @prevent_class_filtering
     def symmetric_difference_update(
@@ -481,10 +479,102 @@ class RelationshipSet(ObjectSet):
         removed = underlying_set.difference(result)
         if removed:
             for rel in self._predicates:
-                self._individual.relationships_disconnect(*removed, rel=rel)
+                self._disconnect(*removed, rel=rel)
 
         added = result.difference(underlying_set)
-        self._individual.relationships_connect(*added, rel=self._predicate)
+        self._connect(*added, rel=self._predicate)
+
+    @prevent_class_filtering
+    def _connect(
+        self,
+        *individuals: OntologyIndividual,
+        rel: Optional[OntologyRelationship] = None,
+    ):
+        individuals = set(individuals)
+
+        # Raise exception if any of the individuals to connect belongs to a
+        # different session.
+        different_session = set(
+            individual
+            for individual in individuals
+            if individual not in self.individual.session
+        )
+        if different_session:
+            raise RuntimeError(
+                f"Cannot connect ontology individuals belonging to a "
+                f"different session: "
+                f"{','.join(str(i) for i in different_session)}."
+                f"Please add them to this session first using `session.add`."
+            )
+
+        rel = rel or self.predicate
+        # Raise exception for predicates that are not a subclass of the
+        # RelationshipSet's ontology predicates.
+        if rel != self.predicate:
+            allowed = (
+                self._predicates if self.predicate is not None else {None}
+            )
+            if rel not in allowed:
+                raise RuntimeError(
+                    f"Predicate {rel} not within the set of allowed "
+                    f"predicates {allowed}"
+                )
+        if rel is None:
+            raise RuntimeError(f"No predicate specified.")
+        rel = rel.identifier
+
+        for individual in individuals:
+            self.individual.session.graph.add(
+                (self.individual.identifier, rel, individual.identifier)
+            )
+
+    @prevent_class_filtering
+    def _disconnect(
+        self,
+        *individuals: OntologyIndividual,
+        rel: Optional[OntologyRelationship] = None,
+    ):
+        individuals = set(individuals)
+
+        # Raise exception if any of the individuals to connect belongs to a
+        # different session.
+        different_session = set(
+            individual
+            for individual in individuals
+            if individual not in self.individual.session
+        )
+        if different_session:
+            raise RuntimeError(
+                f"Cannot disconnect ontology individuals belonging to a "
+                f"different session: "
+                f"{','.join(str(i) for i in different_session)}."
+                f"Please add them to this session first using `session.add`."
+            )
+
+        rel = rel or self.predicate
+        # Raise exception for predicates that are not a subclass of the
+        # RelationshipSet's ontology predicates.
+        if rel != self.predicate:
+            allowed = (
+                self._predicates if self.predicate is not None else {None}
+            )
+            if rel not in allowed:
+                raise RuntimeError(
+                    f"Predicate {rel} not within the set of allowed "
+                    f"predicates {allowed}"
+                )
+        if rel is None:
+            raise RuntimeError(f"No predicate specified.")
+
+        for rel in rel.subclasses:
+            for individual in individuals:
+                self.individual.session.graph.remove(
+                    (
+                        self.individual.identifier,
+                        rel.identifier,
+                        individual.identifier,
+                    )
+                )
 
     # ↑ ------ ↑
     # Public API
@@ -1207,12 +1297,6 @@ class OntologyIndividual(OntologyEntity):
                     f"Expected {OntologyIndividual}, {Identifier} or {str} "
                     f"objects, not {type(x)}."
                 )
-            elif x not in self.session:
-                raise RuntimeError(
-                    "Cannot connect an ontology individual that belongs to "
-                    "a different session, please add it to this session "
-                    "first using `session.add`."
-                )
         individuals = set(individuals)
 
         if isinstance(rel, Identifier):
@@ -1270,12 +1354,6 @@ class OntologyIndividual(OntologyEntity):
                 raise TypeError(
                     f"Expected {OntologyIndividual}, {Identifier} or {str} "
                     f"objects, not {type(x)}."
-                )
-            elif x not in self.session:
-                raise RuntimeError(
-                    "Cannot connect an ontology individual that belongs to "
-                    "a different session, please add it to this session "
-                    "first using `session.add`."
                 )
         individuals = set(individuals)
 
@@ -2059,73 +2137,6 @@ class OntologyIndividual(OntologyEntity):
 
     # Relationship handling
     # ↓ ----------------- ↓
-
-    def relationships_connect(
-        self, *other: OntologyIndividual, rel: OntologyRelationship
-    ):
-        """Connect other ontology individuals to this one.
-
-        If the connected object is associated with the same session, only a
-        link is created. Otherwise, the information associated with the
-        connected object is added to the session of this ontology individual.
-
-        Args:
-            other: The ontology individual(s) to connect.
-            rel: The relationship to use.
-
-        Raises:
-            TypeError: No relationship given.
-
-        Returns:
-            The ontology individual that has been connected,
-            associated with the session of the current ontology individual
-            object.
-        """
-        for individual in other:
-            self.session.merge(individual)
-            self.session.graph.add(
-                (self.identifier, rel.identifier, individual.identifier)
-            )
-
-    def relationships_disconnect(
-        self,
-        *other: OntologyIndividual,
-        rel: Optional[OntologyRelationship] = None,
-    ):
-        """Disconnect ontology individuals from this one.
-
-        Args:
-            other: The ontology individual(s) to disconnect. When not
-                specified, this ontology individual will be disconnected
-                from all connected individuals.
-            rel: This ontology individual will be disconnected from `other`
-                for relationship `rel`. When not specified, this ontology
-                individual will be disconnected from `other` for all
-                relationships.
-        """
-        if rel is None:
-            predicates = set()
-            for predicate in self.session.graph.predicates(
-                self.identifier, None
-            ):
-                try:
-                    relationship = self.session.ontology.from_identifier(
-                        predicate
-                    )
-                    predicates |= {relationship.identifier}
-                except KeyError:
-                    pass
-        else:
-            predicates = {rel.identifier}
-
-        other = other if other else {None}
-        for item in other:
-            s, o = (
-                self.identifier,
-                item.identifier if item is not None else None,
-            )
-            for p in predicates:
-                self.session.graph.remove((s, p, o))
 
     def relationships_iter(
         self,

--- a/simphony_osp/ontology/oclass.py
+++ b/simphony_osp/ontology/oclass.py
@@ -159,9 +159,6 @@ class OntologyClass(OntologyEntity):
         elif self.is_subclass_of(simphony.File):
             from simphony_osp.ontology.interactive.file import File
 
-            path = kwargs.get("path", None)
-            if "path" in kwargs:
-                del kwargs["path"]
             result = File(
                 uid=uid,
                 session=session,
@@ -169,7 +166,6 @@ class OntologyClass(OntologyEntity):
                     kwargs, _skip_checks=_force
                 ),
             )
-            result[simphony.path] = path
             return result
         # TODO: Multiclass individuals.
 

--- a/simphony_osp/ontology/oclass.py
+++ b/simphony_osp/ontology/oclass.py
@@ -345,9 +345,7 @@ class OntologyClass(OntologyEntity):
         Returns:
             The direct superclasses.
         """
-        for o in self.session.graph_and_overlay.objects(
-            self.iri, RDFS.subClassOf
-        ):
+        for o in self.session.graph.objects(self.iri, RDFS.subClassOf):
             try:
                 yield self.session.from_identifier_typed(
                     o, typing=OntologyClass
@@ -361,9 +359,7 @@ class OntologyClass(OntologyEntity):
         Returns:
             The direct subclasses.
         """
-        for s in self.session.graph_and_overlay.subjects(
-            RDFS.subClassOf, self.iri
-        ):
+        for s in self.session.graph.subjects(RDFS.subClassOf, self.iri):
             try:
                 yield self.session.from_identifier_typed(
                     s, typing=OntologyClass
@@ -387,7 +383,7 @@ class OntologyClass(OntologyEntity):
             lambda x: isinstance(x, OntologyClass),
             (
                 self.session.from_identifier(x)
-                for x in self.session.graph_and_overlay.transitiveClosure(
+                for x in self.session.graph.transitiveClosure(
                     closure, self.identifier
                 )
             ),
@@ -411,7 +407,7 @@ class OntologyClass(OntologyEntity):
             lambda x: isinstance(x, OntologyClass),
             (
                 self.session.from_identifier(x)
-                for x in self.session.graph_and_overlay.transitiveClosure(
+                for x in self.session.graph.transitiveClosure(
                     closure, self.identifier
                 )
             ),

--- a/simphony_osp/ontology/parser/owl/keywords.py
+++ b/simphony_osp/ontology/parser/owl/keywords.py
@@ -3,12 +3,8 @@
 IDENTIFIER_KEY = "identifier"
 RDF_FILE_KEY = "ontology_file"
 NAMESPACES_KEY = "namespaces"
-ACTIVE_REL_KEY = "active_relationships"
-DEFAULT_REL_KEY = "default_relationship"
 FILE_FORMAT_KEY = "format"
 REQUIREMENTS_KEY = "requirements"
-REFERENCE_STYLE_KEY = "reference_by_label"
-FILE_HANDLER_KEY = "file"
 
 MANDATORY_KEYS = [IDENTIFIER_KEY, RDF_FILE_KEY, NAMESPACES_KEY]
 
@@ -16,10 +12,6 @@ ALL_KEYS = [
     IDENTIFIER_KEY,
     RDF_FILE_KEY,
     NAMESPACES_KEY,
-    ACTIVE_REL_KEY,
-    DEFAULT_REL_KEY,
     FILE_FORMAT_KEY,
     REQUIREMENTS_KEY,
-    REFERENCE_STYLE_KEY,
-    FILE_HANDLER_KEY,
 ]

--- a/simphony_osp/ontology/parser/parser.py
+++ b/simphony_osp/ontology/parser/parser.py
@@ -2,11 +2,13 @@
 
 Also contains a `Parser` class for backwards compatibility.
 """
+from __future__ import annotations
 
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import Dict, Optional, Set, Tuple
+from pathlib import Path
+from typing import Dict, Set, Union
 
 import yaml
 from rdflib import Graph, URIRef
@@ -56,52 +58,35 @@ class OntologyParser(ABC):
         """Fetch the requirements from the ontology file."""
         pass
 
-    @property
     @abstractmethod
-    def active_relationships(self) -> Tuple[URIRef]:
-        """Fetch the active relationships from the ontology file."""
-        pass
-
-    @property
-    @abstractmethod
-    def default_relationship(self) -> Optional[URIRef]:
-        """Fetch the default relationship from the ontology file."""
-        pass
-
-    @property
-    @abstractmethod
-    def reference_style(self) -> bool:
-        """Whether to reference entities by labels or iri suffix."""
-        pass
-
-    @abstractmethod
-    def install(self, destination: str):
+    def install(self, destination: Union[str, Path]) -> None:
         """Store the parsed files at the given destination.
 
         This function is meant to copy the ontology to the SimPhoNy data
         directory. So usually the destination will be `~/.simphony-osp`.
 
         Args:
-            destination (str): the SimPhoNy data directory.
+            destination: the SimPhoNy data directory.
         """
         pass
 
     @staticmethod
-    def parse_file_path(file_identifier: str):
+    def parse_file_path(file_identifier: Union[str, Path]) -> str:
         """Get the correct file path for a given identifier.
 
         For a given one, i.e. translate non
         paths to osp/core/ontology/files/*.yml
 
         Args:
-            file_identifier (str): A filepath or file identifier
+            file_identifier: A filepath or file identifier.
 
         Returns:
-            str: The translated file path
+            The translated file path.
         """
-        if file_identifier.endswith(".yml"):
-            return file_identifier
-        file_identifier = file_identifier.lower()
+        file_identifier = Path(file_identifier)
+        if str(file_identifier).endswith(".yml"):
+            return str(file_identifier)
+        file_identifier = str(file_identifier).lower()
         a = os.path.join(
             os.path.dirname(__file__),
             "../files",
@@ -115,11 +100,11 @@ class OntologyParser(ABC):
         return os.path.abspath(b)
 
     @staticmethod
-    def load_yaml(path: str):
+    def load_yaml(path: Union[str, Path]):
         """Load the given YAML file.
 
         Args:
-            path (str): the path of the YAML file.
+            path: the path of the YAML file.
         """
         with open(path, "r") as file:
             doc = yaml.safe_load(file)
@@ -132,7 +117,7 @@ class OntologyParser(ABC):
         """Tells whether a given YAML doc is an OWL ontology config file.
 
         Args:
-            doc (dict): the doc obtained after reading the YAML config file.
+            doc: the doc obtained after reading the YAML config file.
         """
         import simphony_osp.ontology.parser.owl.keywords as keywords
 
@@ -141,11 +126,11 @@ class OntologyParser(ABC):
         )
 
     @classmethod
-    def get_parser(cls, path: str) -> "OntologyParser":
+    def get_parser(cls, path: Union[str, Path]) -> OntologyParser:
         """Parse the given YAML files.
 
         Args:
-            path (str): path to the YAML file
+            path: path to the YAML file
         """
         from simphony_osp.ontology.parser.owl.parser import OWLParser
 

--- a/simphony_osp/ontology/utils.py
+++ b/simphony_osp/ontology/utils.py
@@ -1,4 +1,5 @@
 """Utility resources for the ontology module."""
+from __future__ import annotations
 
 import functools
 import importlib
@@ -165,7 +166,7 @@ class DataStructureSet(ABC, MutableSet):
         """Return self^other."""
         return set(self).__xor__(other)
 
-    def __iadd__(self, other: Any) -> "DataStructureSet":
+    def __iadd__(self, other: Any) -> DataStructureSet:
         """Return self+=other (equivalent to self|=other)."""
         if isinstance(other, (Set, MutableSet)):
             # Apparently instances of MutableSet are not instances of Set.
@@ -174,7 +175,7 @@ class DataStructureSet(ABC, MutableSet):
             self.update({other})
         return self
 
-    def __isub__(self, other: Any) -> "DataStructureSet":
+    def __isub__(self, other: Any) -> DataStructureSet:
         """Return self-=other.
 
         Based on `difference_update`.
@@ -186,7 +187,7 @@ class DataStructureSet(ABC, MutableSet):
             self.difference_update({other})
         return self
 
-    def __ior__(self, other: set) -> "DataStructureSet":
+    def __ior__(self, other: set) -> DataStructureSet:
         """Return self|=other.
 
         Should perform the union on the underlying data structure.
@@ -194,7 +195,7 @@ class DataStructureSet(ABC, MutableSet):
         self.update(other)
         return self
 
-    def __iand__(self, other: set) -> "DataStructureSet":
+    def __iand__(self, other: set) -> DataStructureSet:
         """Return self&=other.
 
         Should perform the intersection on the underlying data structure.
@@ -202,7 +203,7 @@ class DataStructureSet(ABC, MutableSet):
         self.intersection_update(other)
         return self
 
-    def __ixor__(self, other: set) -> "DataStructureSet":
+    def __ixor__(self, other: set) -> DataStructureSet:
         """Return self^=other.
 
         Should perform the XOR operation on the underlying data structure.

--- a/simphony_osp/session/session.py
+++ b/simphony_osp/session/session.py
@@ -19,7 +19,6 @@ from typing import (
     Union,
 )
 
-import rdflib
 from rdflib import OWL, RDF, RDFS, SKOS, BNode, Graph, Literal, URIRef
 from rdflib.graph import ReadOnlyGraphAggregate
 from rdflib.plugins.sparql.processor import SPARQLResult
@@ -786,7 +785,6 @@ class Session(Environment):
         Args:
             parser: the ontology parser from where to load the new namespaces.
         """
-
         self.ontology._graph += parser.graph
         for name, iri in parser.namespaces.items():
             self.bind(name, iri)

--- a/simphony_osp/session/session.py
+++ b/simphony_osp/session/session.py
@@ -162,17 +162,21 @@ class Session(Environment):
     Python (string representation of the session). It has no other effect.
     """
 
-    ontology: Union["Session", bool] = None
-    """Another session considered to be the T-Box of this one.
+    @property
+    def ontology(self) -> Session:
+        """Another session considered to be the T-Box of this one.
 
-    In a normal setting, a session is considered only to contain an A-Box.
-    When it is necessary to look for a class, a relationship, an attribute
-    or an annotation property, the session will look there for their
-    definition.
+        In a normal setting, a session is considered only to contain an A-Box.
+        When it is necessary to look for a class, a relationship, an attribute
+        or an annotation property, the session will look there for their
+        definition.
+        """
+        return self._ontology or Session.get_default_session()
 
-    However, if instead of a session the value `True` is set, then this
-    session will also be its own T-Box.
-    """
+    @ontology.setter
+    def ontology(self, value: Optional[Session]) -> None:
+        """Set the T-Box of this session."""
+        self._ontology = value
 
     label_properties: Tuple[URIRef] = (SKOS.prefLabel, RDFS.label)
     """The identifiers of the RDF predicates to be considered as labels.
@@ -218,8 +222,6 @@ class Session(Environment):
         self._graph.commit()
         if self.ontology is not self:
             self.ontology.commit()
-        else:
-            self._overlay.commit()
         self.creation_set = set()
 
     def compute(self, *args, **kwargs) -> None:
@@ -540,8 +542,20 @@ class Session(Environment):
     def clear(self):
         """Clear all the data stored in the session."""
         self._graph.remove((None, None, None))
+        self._namespaces.clear()
+
+        # Reload the essential TBox required by ontologies.
+        if self.ontology is self:
+            for parser in (
+                OntologyParser.get_parser("simphony"),
+                OntologyParser.get_parser("owl"),
+                OntologyParser.get_parser("rdfs"),
+            ):
+                self.ontology.load_parser(parser)
 
     # ↑ --------------------- Public API --------------------- ↑ #
+
+    _ontology: Optional[Session] = None
 
     def __init__(
         self,
@@ -579,7 +593,6 @@ class Session(Environment):
         self._storing = list()
 
         self._namespaces = dict()
-        self._overlay = Graph()
         # Load the essential TBox required by ontologies.
         if self.ontology is self:
             for parser in (
@@ -726,156 +739,9 @@ class Session(Environment):
         return result
 
     @property
-    def active_relationships(self) -> Tuple[OntologyRelationship, ...]:
-        """Get the active relationships defined in the ontology."""
-        # TODO: Transitive closure.
-        return tuple(
-            OntologyRelationship(UID(s), self)
-            for s in self.ontology._overlay.subjects(
-                RDFS.subPropertyOf, simphony_namespace.activeRelationship
-            )
-        )
-
-    @active_relationships.setter
-    def active_relationships(
-        self, value: Union[None, Iterable[OntologyRelationship]]
-    ):
-        """Set the active relationships defined in the ontology."""
-        value = iter(()) if value is None else value
-
-        for triple in self.ontology._overlay.triples(
-            (None, RDFS.subPropertyOf, simphony_namespace.activeRelationship)
-        ):
-            self.ontology._overlay.remove(triple)
-        for relationship in value:
-            self.ontology._overlay.add(
-                (
-                    relationship.iri,
-                    RDFS.subPropertyOf,
-                    simphony_namespace.activeRelationship,
-                )
-            )
-
-    @property
-    def default_relationships(
-        self,
-    ) -> Dict[OntologyNamespace, OntologyRelationship]:
-        """Get the default relationship defined in the ontology.
-
-        Each namespace can have a different default relationship.
-        """
-        default_relationships = {
-            ns: (OntologyRelationship(UID(o), self.ontology),)
-            for ns in self.namespaces
-            for o in self.ontology._overlay.objects(
-                ns.iri, simphony_namespace._default_rel
-            )
-        }
-        for key, value in default_relationships.items():
-            if len(value) > 1:
-                raise RuntimeError(
-                    f"Multiple default relationships defined"
-                    f"for namespace {key}."
-                )
-            else:
-                default_relationships[key] = value[0]
-        return default_relationships
-
-    @default_relationships.setter
-    def default_relationships(
-        self,
-        value: Union[
-            None,
-            OntologyRelationship,
-            Dict[OntologyNamespace, OntologyRelationship],
-        ],
-    ):
-        """Set the default relationships defined in the ontology.
-
-        Each namespace can have a different default relationship.
-
-        Args:
-            value: Sets the same default relationship for all namespaces
-                value is an OntologyRelationship, set different
-                relationships when a dict is provided..
-        """
-        if value is None:
-            remove = ((None, simphony_namespace._default_rel, None),)
-            add = dict()
-        elif isinstance(value, OntologyRelationship):
-            remove = ((None, simphony_namespace._default_rel, None),)
-            add = {ns.iri: value.iri for ns in self.namespaces}
-        elif isinstance(value, Dict):
-            remove = (
-                (ns.iri, simphony_namespace._default_rel, None)
-                for ns in value.keys()
-            )
-            add = {ns.iri: rel.iri for ns, rel in value.items()}
-        else:
-            raise TypeError(
-                f"Expected either None, an OntologyRelationship "
-                f"or a mapping (dictionary) from "
-                f"OntologyNamespace to OntologyRelationship, "
-                f"not {type(value)}."
-            )
-
-        for pattern in remove:
-            self.ontology._overlay.remove(pattern)
-        for ns_iri, rel_iri in add.items():
-            self.ontology._overlay.add(
-                (ns_iri, simphony_namespace._default_rel, rel_iri)
-            )
-
-    @property
-    def reference_styles(self) -> Dict[OntologyNamespace, bool]:
-        """Get the reference styles defined in the ontology.
-
-        Can be either by label (True) or by iri suffix (False).
-        """
-        reference_styles = {ns: False for ns in self.namespaces}
-        true_reference_styles = (
-            s
-            for s in self.ontology._overlay.subjects(
-                simphony_namespace._reference_by_label, Literal(True)
-            )
-        )
-        for s in true_reference_styles:
-            reference_styles[self.get_namespace(s)] = True
-        return reference_styles
-
-    @reference_styles.setter
-    def reference_styles(
-        self, value: Union[bool, Dict[OntologyNamespace, bool]]
-    ):
-        """Set the reference style defined in the ontology.
-
-        Can be either by label (True) or by iri suffix (False).
-        """
-        if isinstance(value, bool):
-            value = {ns: value for ns in self.namespaces}
-        self.ontology._overlay.remove(
-            (None, simphony_namespace._reference_by_label, None)
-        )
-        for key, value in value.items():
-            self.ontology._overlay.add(
-                (
-                    key.iri,
-                    simphony_namespace._reference_by_label,
-                    Literal(value),
-                )
-            )
-
-    @property
     def graph(self) -> Graph:
         """Returns the session's graph."""
         return self._graph
-
-    @property
-    def graph_and_overlay(self) -> Graph:
-        """Returns an aggregate of the session's graph and overlay."""
-        return ReadOnlyGraphAggregate(
-            [self.ontology._graph, self.ontology._overlay]
-        )
 
     @property
     def driver(self) -> Optional["InterfaceDriver"]:
@@ -920,12 +786,8 @@ class Session(Environment):
         Args:
             parser: the ontology parser from where to load the new namespaces.
         """
-        # Force default relationships to be installed before installing a new
-        # ontology.
-        self._check_default_relationship_installed(parser)
 
         self.ontology._graph += parser.graph
-        self.ontology._overlay += self._overlay_from_parser(parser)
         for name, iri in parser.namespaces.items():
             self.bind(name, iri)
 
@@ -1102,7 +964,6 @@ class Session(Environment):
     creation_set: Set[Identifier]
     _namespaces: Dict[URIRef, str]
     _graph: Graph
-    _overlay: Graph
     _driver: Optional["Interface"] = None
 
     @property
@@ -1120,226 +981,6 @@ class Session(Environment):
             )
             if not entity_triples_exist:
                 self.creation_set.add(identifier)
-
-    # ↓ ----------------- Legacy code ----------------- ↓ #
-    """This code should be either modernized or removed."""
-
-    def _update_overlay(self) -> Graph:
-        graph = self._graph
-        overlay = Graph()
-        for namespace, iri in ((ns, ns.iri) for ns in self.namespaces):
-            # Look for duplicate labels.
-            if self.reference_styles:
-                _check_duplicate_labels(graph, iri)
-        _check_namespaces((ns.iri for ns in self.namespaces), graph)
-        self._overlay_add_cuba_triples(self, overlay)
-        self._overlay_add_default_rel_triples(self, overlay)
-        self._overlay_add_reference_style_triples(self, overlay)
-        return overlay
-
-    def _overlay_from_parser(self, parser: OntologyParser) -> Graph:
-        graph = parser.graph
-        overlay = Graph()
-        if parser.reference_style:
-            for namespace, iri in parser.namespaces.items():
-                # Look for duplicate labels.
-                _check_duplicate_labels(graph, iri)
-        _check_namespaces(parser.namespaces.values(), graph)
-        self._overlay_add_cuba_triples(parser, overlay)
-        self._overlay_add_default_rel_triples(parser, overlay)
-        self._overlay_add_reference_style_triples(parser, overlay)
-        return overlay
-
-    def _overlay_add_default_rel_triples(
-        self, parser: Union[OntologyParser, "Session"], overlay: Graph
-    ):
-        """Add the triples to the graph that indicate the default rel.
-
-        The default rel is defined per namespace. However, only one is
-        currently supported per ontology, therefore all namespaces defined in
-        the ontology will have the same default relationship (the one of the
-        package).
-        """
-        if parser.default_relationship is None:
-            return
-        for namespace in parser.namespaces.values():
-            self._graph.remove(
-                (URIRef(namespace), simphony_namespace._default_rel, None)
-            )
-            overlay.remove(
-                (URIRef(namespace), simphony_namespace._default_rel, None)
-            )
-            overlay.add(
-                (
-                    URIRef(namespace),
-                    simphony_namespace._default_rel,
-                    URIRef(parser.default_relationship),
-                )
-            )
-
-    @staticmethod
-    def _overlay_add_cuba_triples(
-        parser: Union[OntologyParser, "Session"], overlay: Graph
-    ):
-        """Add the triples to connect the owl ontology to CUBA."""
-        for iri in parser.active_relationships:
-            # if (iri, RDF.type, OWL.ObjectProperty) not in parser.graph:
-            #     logger.warning(f"Specified relationship {iri} as "
-            #                    f"active relationship, which is not "
-            #                    f"a valid object property in the ontology."
-            #                    f"If such relationship belongs to another "
-            #                    f"ontology, and such ontology is installed, "
-            #                    f"then you may safely ignore this warning.")
-            #     # This requirement is checked later on in
-            #     # `namespace_registry.py`
-            #     # (NamespaceRegistry._check_default_relationship_installed).
-            overlay.add(
-                (
-                    iri,
-                    RDFS.subPropertyOf,
-                    simphony_namespace.activeRelationship,
-                )
-            )
-
-    @staticmethod
-    def _overlay_add_reference_style_triples(
-        parser: Union[OntologyParser, "Session"], overlay: Graph
-    ):
-        """Add a triple to store how the user should reference the entities.
-
-        The reference style (by entity label or by iri suffix) is defined per
-        namespace. However, only one is currently supported per ontology,
-        therefore all namespaces defined in the ontology will have the same
-        reference style (the one of the package).
-        """
-        for namespace in parser.namespaces.values():
-            if parser.reference_style:
-                overlay.add(
-                    (
-                        URIRef(namespace),
-                        simphony_namespace._reference_by_label,
-                        Literal(True),
-                    )
-                )
-
-    def _check_default_relationship_installed(
-        self,
-        parser: OntologyParser,
-        allow_types=frozenset(
-            {
-                rdflib.OWL.ObjectProperty,
-            }
-        ),
-    ):
-        if not parser.default_relationship:
-            return
-        found = False
-        # Check if it is in the namespace to be installed.
-        for s, p, o in parser.graph.triples(
-            (parser.default_relationship, rdflib.RDF.type, None)
-        ):
-            if o in allow_types:
-                found = True
-                break
-        # If not, found, find it in the namespace registry.
-        if not found:
-            for s, p, o in self.graph_and_overlay.triples(
-                (parser.default_relationship, rdflib.RDF.type, None)
-            ):
-                if o in allow_types:
-                    found = True
-                    break
-        if not found:
-            raise ValueError(
-                f"The default relationship "
-                f"{parser.default_relationship} defined for "
-                f"the ontology package {parser.identifier} "
-                f"is not installed."
-            )
-
-    # ↑ ----------------- Legacy code ----------------- ↑ #
-
-
-# ↓ ----------------- Legacy code ----------------- ↓ #
-"""This code should be either modernized or removed."""
-
-
-def _check_duplicate_labels(graph: Graph, namespace: Union[str, URIRef]):
-    # Recycle code methods from the Namespace class. A namespace class
-    # cannot be used directly, as the namespace is being spawned.
-    # This may be useful if the definition of containment for ontology
-    # namespaces ever changes.
-    namespace = rdflib.URIRef(namespace)
-
-    def in_namespace(item):
-        # TODO: very similar to
-        #  `simphony_osp.ontology.namespace.OntologyNamespace.__contains__`,
-        #  integrate somehow.
-        if isinstance(item, BNode):
-            return False
-        elif isinstance(item, URIRef):
-            return item.startswith(namespace)
-        else:
-            return False
-
-    mock_session = type(
-        "",
-        (object,),
-        {"_graph": graph, "label_properties": Session.label_properties},
-    )
-
-    def labels_for_iri(iri):
-        return Session.iter_labels(
-            mock_session, iri, return_prop=False, return_literal=True
-        )
-
-    # Finally, check for the duplicate labels.
-    subjects = set(
-        subject for subject in graph.subjects() if in_namespace(subject)
-    )
-    results = set(
-        ((label.toPython(), label.language or ""), iri)
-        for iri in subjects
-        for label in labels_for_iri(iri)
-    )
-    results = sorted(results)
-    labels, iris = tuple(result[0] for result in results), tuple(
-        result[1] for result in results
-    )
-    coincidence_search = tuple(
-        i for i in range(1, len(labels)) if labels[i - 1] == labels[i]
-    )
-    conflicting_labels = {labels[i]: set() for i in coincidence_search}
-    for i in coincidence_search:
-        conflicting_labels[labels[i]] |= {iris[i - 1], iris[i]}
-    if len(conflicting_labels) > 0:
-        texts = (
-            f"{label[0]}, language "
-            f'{label[1] if label[1] != "" else None}: '
-            f'{", ".join(tuple(str(iri) for iri in iris))}'
-            for label, iris in conflicting_labels.items()
-        )
-        raise KeyError(
-            f"The following labels are assigned to more than "
-            f"one entity in namespace {namespace}; "
-            f'{"; ".join(texts)} .'
-        )
-
-
-def _check_namespaces(namespace_iris: Iterable[URIRef], graph: Graph):
-    namespaces = list(namespace_iris)
-    for s, p, o in graph:
-        pop = None
-        for ns in namespaces:
-            if s.startswith(ns):
-                pop = ns
-        if pop:
-            namespaces.remove(pop)
-        if not namespaces:
-            break
-
-
-# ↑ ----------------- Legacy code ----------------- ↑ #
 
 
 class QueryResult(SPARQLResult):
@@ -1410,4 +1051,5 @@ class QueryResult(SPARQLResult):
 
 
 Session.set_default_session(Session(identifier="default session"))
-Session.ontology = Session(identifier="installed ontologies", ontology=True)
+Session.ontology = Session(identifier="default ontology", ontology=True)
+# This default ontology is later overwritten by simphony_osp/utils/pico.py

--- a/simphony_osp/session/session.py
+++ b/simphony_osp/session/session.py
@@ -170,7 +170,7 @@ class Session(Environment):
         or an annotation property, the session will look there for their
         definition.
         """
-        return self._ontology or Session.get_default_session()
+        return self._ontology or Session.default_ontology
 
     @ontology.setter
     def ontology(self, value: Optional[Session]) -> None:
@@ -553,6 +553,13 @@ class Session(Environment):
                 self.ontology.load_parser(parser)
 
     # ↑ --------------------- Public API --------------------- ↑ #
+
+    default_ontology: Session
+    """The default ontology.
+
+    When no T-Box is explicitly assigned to a session, this is the ontology
+    it makes use of.
+    """
 
     _ontology: Optional[Session] = None
 
@@ -1048,6 +1055,8 @@ class QueryResult(SPARQLResult):
     # ↑ --------------------- Public API --------------------- ↑ #
 
 
+Session.default_ontology = Session(
+    identifier="default ontology", ontology=True
+)
 Session.set_default_session(Session(identifier="default session"))
-Session.ontology = Session(identifier="default ontology", ontology=True)
 # This default ontology is later overwritten by simphony_osp/utils/pico.py

--- a/simphony_osp/tools/__init__.py
+++ b/simphony_osp/tools/__init__.py
@@ -1,5 +1,6 @@
 """Module containing tools for the users of the SimPhoNy OSP."""
 
+import simphony_osp.utils.pico as pico
 from simphony_osp.tools.general import branch, get_relationships_between
 from simphony_osp.tools.import_export import export_cuds, import_cuds
 from simphony_osp.tools.pretty_print import pretty_print
@@ -18,6 +19,8 @@ __all__ = [
     # simphony_osp.tools.import_export
     "export_cuds",
     "import_cuds",
+    # simphony_osp.tools.pico
+    "pico",
     # simphony_osp.tools.pretty_print
     "pretty_print",
     # simphony_osp.tools.search

--- a/simphony_osp/tools/import_export.py
+++ b/simphony_osp/tools/import_export.py
@@ -142,7 +142,7 @@ def export_cuds(
     individual_or_session: Optional = None,
     file: Optional[Union[str, TextIO]] = None,
     format: str = "text/turtle",
-    rel: "OntologyRelationship" = simphony_namespace.activeRelationship,
+    rel: "OntologyRelationship" = OWL.topObjectProperty,
     max_depth: float = float("inf"),
 ) -> Union[str, None]:
     """Exports CUDS in a variety of formats (see the `format` argument).
@@ -281,7 +281,7 @@ def _serialize_session_triples(
 
 def _serialize_individual_json(
     individual,
-    rel=simphony_namespace.activeRelationship,
+    rel=OWL.topObjectProperty,
     max_depth=float("inf"),
     json_dumps=True,
 ):
@@ -326,7 +326,7 @@ def _serialize_individual_json(
 
 def _serialize_individual_triples(
     individual,
-    rel=simphony_namespace.activeRelationship,
+    rel=OWL.topObjectProperty,
     max_depth=float("inf"),
     format: str = "ttl",
 ):
@@ -360,8 +360,8 @@ def _serialize_individual_triples(
             Literal("true", datatype=XSD.boolean),
         )
     )
-    for prefix, iri in individual.session.ontology.graph.namespaces():
-        graph.bind(prefix, iri)
+    for namespace in individual.session.namespaces:
+        graph.bind(namespace.name, namespace.iri)
     for s, p, o in itertools.chain(
         *(individual.triples for individual in individuals)
     ):

--- a/simphony_osp/tools/pico.py
+++ b/simphony_osp/tools/pico.py
@@ -1,0 +1,125 @@
+"""Pico is a commandline tool used to install ontologies."""
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Tuple, Union
+
+from simphony_osp.ontology.namespace import OntologyNamespace
+from simphony_osp.utils.pico import logger, pico
+
+__all__ = ["packages", "namespaces", "install", "uninstall"]
+
+
+def packages() -> Tuple[str]:
+    """Returns the identifiers of all installed packages."""
+    return pico.packages
+
+
+def namespaces() -> Tuple[OntologyNamespace]:
+    """Returns namespace objects for all the installed namespaces."""
+    return pico.namespaces
+
+
+def install(*files: Union[Path, str], overwrite: bool = False) -> None:
+    """Install ontology packages.
+
+    Args:
+        files: Paths of `yml` files describing the ontologies to install.
+            Alternatively, identifiers of ontology packages that are
+            bundled with SimPhoNy.
+        overwrite: Whether to overwrite already installed ontology
+            packages.
+    """
+    return pico.install(*files, overwrite=overwrite)
+
+
+def uninstall(*identifiers: str) -> None:
+    """Uninstall ontology packages.
+
+    Args:
+        identifiers: Identifiers of the ontology packages to uninstall.
+    """
+    return pico.uninstall(*identifiers)
+
+
+def terminal() -> None:
+    """Install ontologies from the terminal."""
+    # Entry point
+    parser = argparse.ArgumentParser(
+        description="This tool manages the ontologies used by SimPhoNy."
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        type=str.upper,
+        help="set the logging level",
+    )
+
+    # --- Available commands ---
+    subparsers = parser.add_subparsers(title="command", dest="command")
+
+    # list
+    subparsers.add_parser("list", help="Lists all the installed ontologies")
+
+    # install
+    install_parser = subparsers.add_parser(
+        "install", help="Install ontologies"
+    )
+    install_parser.add_argument(
+        "files", nargs="+", type=str, help="List of yaml files to install"
+    )
+    install_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite the existing ontologies, if they are already "
+        "installed",
+    )
+
+    # uninstall parser
+    uninstall_parser = subparsers.add_parser(
+        "uninstall", help="Uninstall ontologies"
+    )
+    uninstall_parser.add_argument(
+        "packages",
+        nargs="+",
+        type=str,
+        help="List of ontology packages to uninstall",
+    )
+
+    args = parser.parse_args()
+    logging.getLogger("simphony_osp").setLevel(
+        getattr(logging, args.log_level)
+    )
+
+    try:
+        installed_identifiers = list(pico.packages)
+        if args.command == "install" and args.overwrite:
+            pico.install(*args.files, overwrite=True)
+        elif args.command == "install":
+            pico.install(*args.files, overwrite=False)
+        elif args.command == "uninstall":
+            if args.packages == ["all"]:
+                args.packages = installed_identifiers
+            pico.uninstall(*args.packages)
+        elif args.command == "list":
+            print("Packages:")
+            print("\n".join(map(lambda x: "\t- " + x, installed_identifiers)))
+            from simphony_osp.session.session import Session
+
+            installed_namespaces = tuple(
+                namespace.name for namespace in Session.ontology.namespaces
+            )
+            print("Namespaces:")
+            print("\n".join(map(lambda x: "\t- " + x, installed_namespaces)))
+    except Exception:
+        logger.error("An Exception occurred during installation.", exc_info=1)
+        if args.log_level != "DEBUG":
+            logger.error(
+                "Consider running 'pico --log-level debug %s ...'"
+                % args.command
+            )
+
+
+if __name__ == "__main__":
+    terminal()

--- a/simphony_osp/tools/pico.py
+++ b/simphony_osp/tools/pico.py
@@ -105,10 +105,9 @@ def terminal() -> None:
         elif args.command == "list":
             print("Packages:")
             print("\n".join(map(lambda x: "\t- " + x, installed_identifiers)))
-            from simphony_osp.session.session import Session
 
             installed_namespaces = tuple(
-                namespace.name for namespace in Session.ontology.namespaces
+                namespace.name for namespace in pico.ontology.namespaces
             )
             print("Namespaces:")
             print("\n".join(map(lambda x: "\t- " + x, installed_namespaces)))

--- a/simphony_osp/tools/semantic2dot.py
+++ b/simphony_osp/tools/semantic2dot.py
@@ -354,7 +354,7 @@ def run_from_terminal():
     namespaces = list()
     for x in args.to_plot:
         try:
-            namespaces.append(Session.ontology.get_namespace(x))
+            namespaces.append(Session.default_ontology.get_namespace(x))
             logger.warning("Using installed version of namespace %s" % x)
             continue
         except KeyError:
@@ -362,11 +362,11 @@ def run_from_terminal():
         parser = OntologyParser.get_parser(x)
         for iri in parser.namespaces.values():
             try:
-                namespaces.append(Session.ontology.get_namespace(iri))
+                namespaces.append(Session.default_ontology.get_namespace(iri))
                 logger.warning("Using installed version of namespace %s" % iri)
             except KeyError:
-                Session.ontology.load_parser(parser)
-                namespaces.append(Session.ontology.get_namespace(iri))
+                Session.default_ontology.load_parser(parser)
+                namespaces.append(Session.default_ontology.get_namespace(iri))
 
     # Convert the ontology to dot
     converter = Semantic2Dot(*namespaces, group=args.group)

--- a/simphony_osp/utils/pico.py
+++ b/simphony_osp/utils/pico.py
@@ -427,9 +427,9 @@ class Pico:
 
         return path
 
-    def set_default_installation_path(self, value: Optional[Union[str,
-                                                                  Path]]) \
-            -> None:
+    def set_default_installation_path(
+        self, value: Optional[Union[str, Path]]
+    ) -> None:
         """Set the path where ontologies are installed by default."""
         path = self.path
 

--- a/simphony_osp/utils/pico.py
+++ b/simphony_osp/utils/pico.py
@@ -177,7 +177,7 @@ class Pico:
     @property
     def namespaces(self) -> Tuple[OntologyNamespace]:
         """Returns namespace objects for all the installed namespaces."""
-        return tuple(Session.ontology.namespaces)
+        return tuple(self.ontology.namespaces)
 
     def install(
         self, *files: Union[Path, str], overwrite: bool = False
@@ -507,4 +507,4 @@ class Pico:
 # Create a pico singleton for the default directory and set the installed
 # packages as the default ontology.
 pico = Pico()
-Session.ontology = pico.ontology
+Session.default_ontology = pico.ontology

--- a/tests/benchmark_ontology_api.py
+++ b/tests/benchmark_ontology_api.py
@@ -13,8 +13,8 @@ from .benchmark import Benchmark
 try:
     from osp.core.namespaces import city
 except ImportError:  # When the city ontology is not installed.
-    Session.ontology.load_parser(OntologyParser.get_parser("city"))
-    city = Session.ontology.get_namespace("city")
+    Session.default_ontology.load_parser(OntologyParser.get_parser("city"))
+    city = Session.default_ontology.get_namespace("city")
 
 
 DEFAULT_SIZE = 500

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,15 +4,15 @@ The public API methods are the methods that are available to the users,
 and available in the user documentation.
 """
 
-import tempfile
-import unittest
 import os
 import shutil
+import tempfile
+import unittest
 from decimal import Decimal
+from importlib import import_module
+from pathlib import Path
 from types import MappingProxyType
 from typing import Hashable
-from pathlib import Path
-from importlib import import_module
 
 from rdflib import RDFS, SKOS, XSD, Graph, Literal, URIRef
 
@@ -25,8 +25,8 @@ from simphony_osp.ontology.parser import OntologyParser
 from simphony_osp.ontology.relationship import OntologyRelationship
 from simphony_osp.session.session import Session
 from simphony_osp.tools import sparql
+from simphony_osp.tools.pico import install, namespaces, packages, uninstall
 from simphony_osp.utils.pico import pico
-from simphony_osp.tools.pico import install, uninstall, packages, namespaces
 
 
 class TestSessionAPI(unittest.TestCase):
@@ -1615,9 +1615,7 @@ class TestPico(unittest.TestCase):
         The new TBox contains SimPhoNy, OWL, RDFS and FOAF.
         """
         self.path = Path(".TEST_OSP_CORE_INSTALLATION").absolute()
-        os.makedirs(
-            self.path, exist_ok=True
-        )
+        os.makedirs(self.path, exist_ok=True)
 
         pico.set_default_installation_path(self.path)
 
@@ -1628,11 +1626,14 @@ class TestPico(unittest.TestCase):
 
     def test_install(self):
         """Test the installation of ontologies."""
-        self.assertRaises(ModuleNotFoundError,
-                          import_module, 'city',
-                          'simphony_osp.namespaces')
+        self.assertRaises(
+            ModuleNotFoundError,
+            import_module,
+            "city",
+            "simphony_osp.namespaces",
+        )
 
-        install('city')
+        install("city")
 
         from simphony_osp.namespaces import city
 
@@ -1643,64 +1644,68 @@ class TestPico(unittest.TestCase):
         import simphony_osp.namespaces as namespaces_module
 
         # Install the ontology first and guarantee that it worked.
-        self.assertRaises(ModuleNotFoundError,
-                          import_module, 'city',
-                          'simphony_osp.namespaces')
-        install('city')
+        self.assertRaises(
+            ModuleNotFoundError,
+            import_module,
+            "city",
+            "simphony_osp.namespaces",
+        )
+        install("city")
 
         from simphony_osp.namespaces import city
+
         self.assertTrue(city.City)
 
         # Now test uninstallation.
-        uninstall('city')
-        self.assertRaises(ModuleNotFoundError,
-                          import_module, 'city',
-                          'simphony_osp.namespaces')
+        uninstall("city")
+        self.assertRaises(
+            ModuleNotFoundError,
+            import_module,
+            "city",
+            "simphony_osp.namespaces",
+        )
         self.assertRaises(
             AttributeError, lambda: getattr(namespaces_module, "city")
         )
         self.assertRaises(AttributeError, lambda: city.City)
 
         # Test that reinstalling makes the existing namespace work again.
-        install('city')
+        install("city")
         self.assertTrue(city.City)
 
     def test_packages(self):
         """Test listing installed packages."""
         self.assertTupleEqual(tuple(), packages())
-        install('city')
-        self.assertTupleEqual(('city', ), packages())
-        uninstall('city')
+        install("city")
+        self.assertTupleEqual(("city",), packages())
+        uninstall("city")
         self.assertTupleEqual(tuple(), packages())
 
     def test_namespaces(self):
         """Test listing ontology namespaces."""
         self.assertDictEqual(
             {
-                "simphony":
-                    URIRef('https://www.simphony-project.eu/simphony#'),
-                "owl":
-                    URIRef('http://www.w3.org/2002/07/owl#'),
-                "rdfs":
-                    URIRef('http://www.w3.org/2000/01/rdf-schema#'),
-             },
-            {ns.name: ns.iri for ns in namespaces()}
+                "simphony": URIRef(
+                    "https://www.simphony-project.eu/simphony#"
+                ),
+                "owl": URIRef("http://www.w3.org/2002/07/owl#"),
+                "rdfs": URIRef("http://www.w3.org/2000/01/rdf-schema#"),
+            },
+            {ns.name: ns.iri for ns in namespaces()},
         )
 
-        install('city')
+        install("city")
 
         self.assertDictEqual(
             {
-                "simphony":
-                    URIRef('https://www.simphony-project.eu/simphony#'),
-                "owl":
-                    URIRef('http://www.w3.org/2002/07/owl#'),
-                "rdfs":
-                    URIRef('http://www.w3.org/2000/01/rdf-schema#'),
-                "city":
-                    URIRef('https://www.simphony-project.eu/city#'),
-             },
-            {ns.name: ns.iri for ns in namespaces()}
+                "simphony": URIRef(
+                    "https://www.simphony-project.eu/simphony#"
+                ),
+                "owl": URIRef("http://www.w3.org/2002/07/owl#"),
+                "rdfs": URIRef("http://www.w3.org/2000/01/rdf-schema#"),
+                "city": URIRef("https://www.simphony-project.eu/city#"),
+            },
+            {ns.name: ns.iri for ns in namespaces()},
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,13 +43,13 @@ class TestSessionAPI(unittest.TestCase):
         """
         cls.ontology = Session(identifier="test-tbox", ontology=True)
         cls.ontology.load_parser(OntologyParser.get_parser("city"))
-        cls.prev_default_ontology = Session.ontology
-        Session.ontology = cls.ontology
+        cls.prev_default_ontology = Session.default_ontology
+        Session.default_ontology = cls.ontology
 
     @classmethod
     def tearDownClass(cls):
         """Restore the previous default TBox."""
-        Session.ontology = cls.prev_default_ontology
+        Session.default_ontology = cls.prev_default_ontology
 
     def test_identifier(self):
         """Test the identifier attribute of the session."""
@@ -567,13 +567,13 @@ class TestOntologyAPICity(unittest.TestCase):
         """
         cls.ontology = Session(identifier="test-tbox", ontology=True)
         cls.ontology.load_parser(OntologyParser.get_parser("city"))
-        cls.prev_default_ontology = Session.ontology
-        Session.ontology = cls.ontology
+        cls.prev_default_ontology = Session.default_ontology
+        Session.default_ontology = cls.ontology
 
     @classmethod
     def tearDownClass(cls):
         """Restore the previous default TBox."""
-        Session.ontology = cls.prev_default_ontology
+        Session.default_ontology = cls.prev_default_ontology
 
     def test_attribute(self):
         """Tests the OntologyAttribute subclass.
@@ -1385,13 +1385,13 @@ class TestOntologyAPIFOAF(unittest.TestCase):
 
         cls.ontology = Session(identifier="test-tbox", ontology=True)
         cls.ontology.load_parser(OntologyParser.get_parser(yml_path))
-        cls.prev_default_ontology = Session.ontology
-        Session.ontology = cls.ontology
+        cls.prev_default_ontology = Session.default_ontology
+        Session.default_ontology = cls.ontology
 
     @classmethod
     def tearDownClass(cls):
         """Restore the previous default TBox."""
-        Session.ontology = cls.prev_default_ontology
+        Session.default_ontology = cls.prev_default_ontology
 
     def test_annotation(self):
         """Tests the OntologyAnnotation subclass.
@@ -1411,14 +1411,13 @@ class TestOntologyAPIFOAF(unittest.TestCase):
 
         DOES include methods inherited from OntologyEntity.
         """
-        ontology = self.ontology
         from simphony_osp.namespaces import foaf
 
         # Test annotation of ontology individuals.
         group = foaf.Group()
-        person = foaf.Person(session=ontology)
-        another_person = foaf.Person(session=ontology)
-        one_more_person = foaf.Person(session=ontology)
+        person = foaf.Person()
+        another_person = foaf.Person()
+        one_more_person = foaf.Person()
         group[foaf.member] = {person, another_person, one_more_person}
         group[foaf.membershipClass] = foaf.Person
         self.assertSetEqual({foaf.Person}, group[foaf.membershipClass])
@@ -1722,13 +1721,13 @@ class TestContainer(unittest.TestCase):
         """
         ontology = Session(identifier="test-tbox", ontology=True)
         ontology.load_parser(OntologyParser.get_parser("city"))
-        cls.prev_default_ontology = Session.ontology
-        Session.ontology = ontology
+        cls.prev_default_ontology = Session.default_ontology
+        Session.default_ontology = ontology
 
     @classmethod
     def tearDownClass(cls):
         """Restore the previous default TBox."""
-        Session.ontology = cls.prev_default_ontology
+        Session.default_ontology = cls.prev_default_ontology
 
     def test_container(self):
         """Test the container ontology individual."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1846,8 +1846,8 @@ class TestContainer(unittest.TestCase):
         session_2 = Session()
 
         klaus = city.Citizen(name="Klaus", age=5)
-        session_1.update(klaus)
-        session_2.update(klaus)
+        session_1.add(klaus)
+        session_2.add(klaus)
         klaus_1 = session_1.from_identifier(klaus.identifier)
         klaus_1.age = 10
         klaus_2 = session_2.from_identifier(klaus.identifier)

--- a/tests/test_importexport.yml
+++ b/tests/test_importexport.yml
@@ -1,7 +1,5 @@
 ---
 identifier: test_importexport
 ontology_file: "./test_simphony_osp_tools_importexport_ontology.owl"
-reference_by_label: True
 namespaces:
     test_importexport: "http://example.org/test-ontology#"
-active_relationships: []

--- a/tests/test_simphony_osp_session.py
+++ b/tests/test_simphony_osp_session.py
@@ -36,25 +36,7 @@ class TestLoadParsers(unittest.TestCase):
         city_namespaces = {"city": "https://www.simphony-project.eu/city#"}
         foaf_namespaces = {"foaf": "http://xmlns.com/foaf/0.1/"}
         dcat2_namespaces = {"dcat2": "http://www.w3.org/ns/dcat#"}
-        emmo_namespaces = {
-            "annotations": "http://emmo.info/emmo/top/annotations#",
-            "holistic": "http://emmo.info/emmo/middle/holistic#",
-            "isq": "http://emmo.info/emmo/middle/isq#",
-            "manufacturing": "http://emmo.info/emmo/middle/manufacturing#",
-            "materials": "http://emmo.info/emmo/middle/materials#",
-            "math": "http://emmo.info/emmo/middle/math#",
-            "meretopology": "http://emmo.info/emmo/top/mereotopology#",
-            "metrology": "http://emmo.info/emmo/middle/metrology#",
-            "models": "http://emmo.info/emmo/middle/models#",
-            "perceptual": "http://emmo.info/emmo/middle/perceptual#",
-            "physical": "http://emmo.info/emmo/top/physical#",
-            "physicalistic": "http://emmo.info/emmo/middle/physicalistic#",
-            "properties": "http://emmo.info/emmo/middle/properties#",
-            "reductionistic": "http://emmo.info/emmo/middle/reductionistic#",
-            "semiotics": "http://emmo.info/emmo/middle/semiotics#",
-            "siunits": "http://emmo.info/emmo/middle/siunits#",
-            "top": "http://emmo.info/emmo/top#",
-        }
+        emmo_namespaces = {"emmo": "http://emmo.info/emmo#"}
         expected_namespaces = dict()
         for nss in (
             required_namespaces,
@@ -64,104 +46,15 @@ class TestLoadParsers(unittest.TestCase):
             city_namespaces,
         ):
             expected_namespaces.update(nss)
-        self.assertSetEqual(
-            set(
-                OntologyNamespace(iri=iri, name=name, ontology=self.ontology)
-                for name, iri in expected_namespaces.items()
-            ),
-            set(self.ontology.namespaces),
+        self.assertDictEqual(
+            expected_namespaces,
+            {ns.name: str(ns.iri) for ns in self.ontology.namespaces},
         )
 
         # Check that names of the namespaces were loaded.
         self.assertSetEqual(
             set(expected_namespaces.keys()),
             set(ns.name for ns in self.ontology.namespaces),
-        )
-
-        # Check that the default relationships were properly loaded.
-        expected_default_relationships = {
-            OntologyNamespace(
-                iri=iri, name=name, ontology=self.ontology
-            ): OntologyRelationship(
-                uid=UID(
-                    "http://emmo.info/emmo/top/mereotopology#"
-                    "EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f"
-                ),
-                session=self.ontology,
-            )
-            for name, iri in emmo_namespaces.items()
-        }
-        expected_default_relationships.update(
-            {
-                OntologyNamespace(
-                    iri="https://www.simphony-project.eu/city#",
-                    name="city",
-                    ontology=self.ontology,
-                ): OntologyRelationship(
-                    uid=UID("https://www.simphony-project.eu/city#hasPart"),
-                    session=self.ontology,
-                )
-            }
-        )
-        expected_default_relationships.update(
-            {
-                OntologyNamespace(
-                    iri="http://www.w3.org/2002/07/owl#",
-                    name="owl",
-                    ontology=self.ontology,
-                ): OntologyRelationship(
-                    uid=UID("http://www.w3.org/2002/07/owl#topObjectProperty"),
-                    session=self.ontology,
-                )
-            }
-        )
-        self.assertDictEqual(
-            expected_default_relationships, self.ontology.default_relationships
-        )
-
-        # Check that the active relationships were properly loaded.
-        self.assertSetEqual(
-            {
-                OntologyRelationship(
-                    uid=UID(
-                        "http://emmo.info/emmo/top/mereotopology#"
-                        "EMMO_8c898653_1118_4682_9bbf_6cc334d16a99"
-                    ),
-                    session=self.ontology,
-                ),
-                OntologyRelationship(
-                    uid=UID(
-                        "http://emmo.info/emmo/middle/semiotics#"
-                        "EMMO_60577dea_9019_4537_ac41_80b0fb563d41"
-                    ),
-                    session=self.ontology,
-                ),
-                OntologyRelationship(
-                    uid=UID(
-                        "https://www.simphony-project.eu/"
-                        "simphony#activeRelationship"
-                    ),
-                    session=self.ontology,
-                ),
-                OntologyRelationship(
-                    uid=UID("https://www.simphony-project.eu/city#encloses"),
-                    session=self.ontology,
-                ),
-            },
-            set(self.ontology.active_relationships),
-        )
-
-        # Check that the reference styles were properly loaded.
-        self.assertDictEqual(
-            {
-                OntologyNamespace(
-                    iri=iri, name=name, ontology=self.ontology
-                ): True
-                if name in emmo_namespaces
-                else False
-                for name, iri in expected_namespaces.items()
-            },
-            self.ontology.reference_styles,
         )
 
         # Try to fetch all the namespaces by name.

--- a/tests/test_simphony_osp_session.py
+++ b/tests/test_simphony_osp_session.py
@@ -2,11 +2,8 @@
 
 import unittest
 
-from simphony_osp.ontology.namespace import OntologyNamespace
 from simphony_osp.ontology.parser import OntologyParser
-from simphony_osp.ontology.relationship import OntologyRelationship
 from simphony_osp.session.session import Session
-from simphony_osp.utils.datatypes import UID
 
 
 class TestLoadParsers(unittest.TestCase):

--- a/tests/test_simphony_osp_tools_importexport.py
+++ b/tests/test_simphony_osp_tools_importexport.py
@@ -4,6 +4,7 @@ import io
 import json
 import unittest
 from pathlib import Path
+from typing import Iterable, List, Optional, Tuple, Type
 
 from rdflib import Graph, URIRef
 from rdflib.compare import isomorphic
@@ -13,24 +14,6 @@ from simphony_osp.ontology.individual import OntologyIndividual
 from simphony_osp.ontology.parser import OntologyParser
 from simphony_osp.session.session import Session
 from simphony_osp.tools import branch, export_cuds, import_cuds
-
-# Load the ontology for the test.
-try:
-    from simphony_osp.namespaces import test_importexport
-except ImportError:  # If the ontology is not installed.
-    Session.ontology.load_parser(
-        OntologyParser.get_parser(
-            str(Path(__file__).parent / "test_importexport.owl.yml")
-        )
-    )
-    test_importexport = Session.ontology.get_namespace("test_importexport")
-
-# Load also the city ontology.
-try:
-    from simphony_osp.namespaces import city
-except ImportError:  # When the city ontology is not installed.
-    Session.ontology.load_parser(OntologyParser.get_parser("city"))
-    city = Session.ontology.get_namespace("city")
 
 
 def json_ld_equal(a, b):
@@ -73,6 +56,30 @@ class TestImportExport(unittest.TestCase):
     the file is tested against the loaded data.
     """
 
+    ontology: Session
+    prev_default_ontology: Session
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a TBox and set it as the default ontology.
+
+        The new TBox contains SimPhoNy, OWL, RDFS and FOAF.
+        """
+        cls.ontology = Session(identifier="test-tbox", ontology=True)
+        cls.ontology.load_parser(OntologyParser.get_parser("city"))
+        cls.ontology.load_parser(
+            OntologyParser.get_parser(
+                str(Path(__file__).parent / "test_importexport.yml")
+            )
+        )
+        cls.prev_default_ontology = Session.default_ontology
+        Session.default_ontology = cls.ontology
+
+    @classmethod
+    def tearDownClass(cls):
+        """Restore the previous default TBox."""
+        Session.default_ontology = cls.prev_default_ontology
+
     def test_application_rdf_xml(self):
         """Test importing and exporting the `application/rdf+xml` mime type."""
         with Session() as session:
@@ -83,7 +90,7 @@ class TestImportExport(unittest.TestCase):
             loaded_objects = import_cuds(
                 test_data_path, format="application/rdf+xml"
             )
-            data_integrity(self, session, loaded_objects, label="import")
+            self.data_integrity(session, loaded_objects, label="import")
             exported_file = io.StringIO()
             export_cuds(file=exported_file, format="application/rdf+xml")
             exported_file.seek(0)
@@ -91,7 +98,7 @@ class TestImportExport(unittest.TestCase):
             exported_objects = import_cuds(
                 exported_file, format="application/rdf+xml"
             )
-            data_integrity(self, session, exported_objects, label="export")
+            self.data_integrity(session, exported_objects, label="export")
 
     def test_application_rdf_xml_guess_format(self):
         """Test guessing and importing the `application/rdf+xml` mime type."""
@@ -101,7 +108,7 @@ class TestImportExport(unittest.TestCase):
                 / "test_simphony_osp_tools_importexport_data.owl"
             )
             loaded_objects = import_cuds(test_data_path)
-            data_integrity(self, session, loaded_objects, label="import")
+            self.data_integrity(session, loaded_objects, label="import")
 
     def test_text_turtle(self):
         """Test importing and exporting the `text/turtle` mime type."""
@@ -111,13 +118,13 @@ class TestImportExport(unittest.TestCase):
                 / "test_simphony_osp_tools_importexport_data.ttl"
             )
             loaded_objects = import_cuds(test_data_path, format="text/turtle")
-            data_integrity(self, session, loaded_objects, label="import")
+            self.data_integrity(session, loaded_objects, label="import")
             exported_file = io.StringIO()
             export_cuds(file=exported_file, format="text/turtle")
             exported_file.seek(0)
         with Session() as session:
             exported_objects = import_cuds(exported_file, format="text/turtle")
-            data_integrity(self, session, exported_objects, label="export")
+            self.data_integrity(session, exported_objects, label="export")
 
     def test_text_turtle_guess_format(self):
         """Test guessing and importing the `text/turtle` mime type."""
@@ -127,7 +134,7 @@ class TestImportExport(unittest.TestCase):
                 / "test_simphony_osp_tools_importexport_data.ttl"
             )
             loaded_objects = import_cuds(test_data_path)
-            data_integrity(self, session, loaded_objects, label="import")
+            self.data_integrity(session, loaded_objects, label="import")
 
     def test_application_json(self):
         """Test importing and exporting the `application/ld+json` mime type."""
@@ -139,7 +146,7 @@ class TestImportExport(unittest.TestCase):
             loaded_objects = import_cuds(
                 test_data_path, format="application/ld+json"
             )
-            data_integrity(self, session, loaded_objects, label="import")
+            self.data_integrity(session, loaded_objects, label="import")
             exported_file = io.StringIO()
             export_cuds(file=exported_file, format="application/ld+json")
             exported_file.seek(0)
@@ -148,7 +155,7 @@ class TestImportExport(unittest.TestCase):
             exported_objects = import_cuds(
                 exported_file, format="application/ld+json"
             )
-            data_integrity(self, session, exported_objects, label="export")
+            self.data_integrity(session, exported_objects, label="export")
 
     def test_application_json_guess_format(self):
         """Test guessing and importing the `application/ld+json` mime type."""
@@ -158,13 +165,15 @@ class TestImportExport(unittest.TestCase):
                 / "test_simphony_osp_tools_importexport_data.json"
             )
             loaded_objects = import_cuds(test_data_path)
-            data_integrity(self, session, loaded_objects, label="import")
+            self.data_integrity(session, loaded_objects, label="import")
 
     def test_application_json_doc_city(self):
         """Test importing the `application/ld+json` mime type from doc dict.
 
         This test uses a city ontology instead.
         """
+        from simphony_osp.namespaces import city
+
         # Importing
         test_data_path = str(
             Path(__file__).parent
@@ -213,6 +222,8 @@ class TestImportExport(unittest.TestCase):
 
         This test uses the city ontology.
         """
+        from simphony_osp.namespaces import city
+
         # Exporting
         c = city.City(name="Freiburg", coordinates=[47, 7])
         p1 = city.Citizen(name="Peter", age=25)
@@ -236,7 +247,7 @@ class TestImportExport(unittest.TestCase):
                 loaded_objects = import_cuds(
                     test_data_file, format="text/turtle"
                 )
-                data_integrity(self, session, loaded_objects, label="import")
+                self.data_integrity(session, loaded_objects, label="import")
 
     def test_text_turtle_file_stringio(self):
         """Test importing the `text/turtle` mime type from a file-like."""
@@ -249,7 +260,7 @@ class TestImportExport(unittest.TestCase):
                 test_data = test_data_file.read()
             test_data = io.StringIO(test_data)
             loaded_objects = import_cuds(test_data, format="text/turtle")
-            data_integrity(self, session, loaded_objects, label="import")
+            self.data_integrity(session, loaded_objects, label="import")
 
     def test_text_turtle_another_session(self):
         """Test to a non-default session."""
@@ -275,136 +286,146 @@ class TestImportExport(unittest.TestCase):
                 )
 
             # Test correctness in the other session.
-            data_integrity(
-                self, another_session, loaded_objects, label="import"
+            self.data_integrity(
+                another_session, loaded_objects, label="import"
             )
 
+    def data_integrity(
+        self,
+        session: Session,
+        loaded_objects: List[OntologyIndividual],
+        label: Optional[str] = None,
+    ):
+        """Checks that the data was loaded correctly into a session.
 
-def data_integrity(testcase, session, loaded_objects, label=None):
-    """Checks that the data was loaded correctly into a session.
+        Args:
+            session: the session where the imported objects have been
+                loaded.
+            loaded_objects: a list with the loaded cuds objects.
+            label: a label for the subtests (for example 'import' or
+                'export'). Makes distinguishing the different integrity checks
+                done during a test easier.
+        """
+        from simphony_osp.namespaces import test_importexport
 
-    Args:
-        testcase (unittest.TestCase): the test case where this function is
-            being called.
-        session (Session): the session where the imported objects have been
-            loaded.
-        loaded_objects (List[Cuds]): a list with the loaded cuds objects.
-        label(str): a label for the subtests (for example 'import' or
-            'export'). Makes distinguishing the different integrity checks
-            done during a test easier.
-    """
-    if label:
-        label = f"({str(label)}) "
-    else:
-        label = ""
+        if label:
+            label = f"({str(label)}) "
+        else:
+            label = ""
 
-    # Load the expected objects from their URI, as an incorrect
-    # number of them may be loaded when calling import_cuds.
-    expected_objects = tuple(
-        session.from_identifier(
-            URIRef(f"http://example.org/test-ontology#x_{i}")
+        # Load the expected objects from their URI, as an incorrect
+        # number of them may be loaded when calling import_cuds.
+        expected_objects = tuple(
+            session.from_identifier(
+                URIRef(f"http://example.org/test-ontology#x_{i}")
+            )
+            for i in range(1, 5)
         )
-        for i in range(1, 5)
-    )
-    # Each individual in the file
-    # represents a "Block" placed in a line. Therefore they may be
-    # called object[1], object[2], object[3] and object[4].
-    object = {i: obj for i, obj in enumerate(expected_objects, 1)}
+        # Each individual in the file
+        # represents a "Block" placed in a line. Therefore they may be
+        # called object[1], object[2], object[3] and object[4].
+        object = {i: obj for i, obj in enumerate(expected_objects, 1)}
 
-    # Test number of loaded CUDS.
-    with testcase.subTest(
-        msg=f"{label}"
-        f"Tests whether the number of loaded CUDS "
-        "objects is the expected one."
-        "\n"
-        "Each individual has its x value assigned to "
-        "the owl:DataTypeProperty 'x'."
+        # Test number of loaded CUDS.
+        with self.subTest(
+            msg=f"{label}"
+            f"Tests whether the number of loaded CUDS "
+            "objects is the expected one."
+            "\n"
+            "Each individual has its x value assigned to "
+            "the owl:DataTypeProperty 'x'."
+        ):
+            self.assertEqual(4, len(loaded_objects))
+
+        # Test attributes.
+        with self.subTest(
+            msg=f"{label}"
+            f"Tests whether attributes are correctly "
+            "retrieved."
+            "\n"
+            "Each individual has its x value assigned to "
+            "the owl:DataTypeProperty 'x'."
+        ):
+            for index, cuds in object.items():
+                self.assertEqual(getattr(cuds, "x"), index)
+
+        # Test classes.
+        with self.subTest(
+            msg=f"{label}"
+            "Tests that the loaded CUDS objects belong to "
+            "the correct classes."
+        ):
+            # Blocks 1, 2 and 4 are both blocks and forests.
+            expected_classes = (
+                test_importexport.Block,
+                test_importexport.Forest,
+            )
+            loaded_classes_for_object = tuple(
+                object[i].classes for i in range(1, 2, 4)
+            )
+
+            self.sub_test_classes(
+                expected_classes, loaded_classes_for_object, label=label
+            )
+
+            # Block 3 is both a block and water.
+            expected_classes = (
+                test_importexport.Block,
+                test_importexport.Water,
+            )
+            loaded_classes_for_object = (object[3].classes,)
+
+            self.sub_test_classes(
+                expected_classes, loaded_classes_for_object, label=label
+            )
+
+        # Test relationships.
+        with self.subTest(
+            msg=f"{str(label)}"
+            "Checks the loaded relationships between CUDS "
+            "objects."
+        ):
+            for i in range(1, 4):
+                cuds = object[i]
+                neighbor = cuds.get(rel=test_importexport.isLeftOf).one()
+                self.assertEqual(neighbor, object[i + 1])
+                neighbor = cuds.get(rel=test_importexport.isNextTo).one()
+                self.assertEqual(neighbor, object[i + 1])
+
+    def sub_test_classes(
+        self,
+        expected_classes: Tuple[Type, ...],
+        loaded_classes_for_object: Tuple[Iterable[Type], ...],
+        label: Optional[str] = None,
     ):
-        testcase.assertEqual(4, len(loaded_objects))
+        """Compares items on a tuple of expected classes with loaded classes.
 
-    # Test attributes.
-    with testcase.subTest(
-        msg=f"{label}"
-        f"Tests whether attributes are correctly "
-        "retrieved."
-        "\n"
-        "Each individual has its x value assigned to "
-        "the owl:DataTypeProperty 'x'."
-    ):
-        for index, cuds in object.items():
-            testcase.assertEqual(getattr(cuds, "x"), index)
+        Args:
+            expected_classes: A tuple wit the expected
+                classes, in any ordering.
+            loaded_classes_for_object: Each
+                element of the tuple is an iterable representing an ontology
+                entity, and each iterable yields the ontology classes of such
+                entity.
+            label: a label for the subtests (for example 'import' or
+                'export'). Makes distinguishing the different integrity checks
+                done during a test easier.
+        """
+        if label:
+            label = f"({str(label)}) "
+        else:
+            label = ""
 
-    # Test classes.
-    with testcase.subTest(
-        msg=f"{label}"
-        "Tests that the loaded CUDS objects belong to "
-        "the correct classes."
-    ):
-        # Blocks 1, 2 and 4 are both blocks and forests.
-        expected_classes = (test_importexport.Block, test_importexport.Forest)
-        loaded_classes_for_object = tuple(
-            object[i].classes for i in range(1, 2, 4)
-        )
-
-        sub_test_classes(
-            testcase, expected_classes, loaded_classes_for_object, label=label
-        )
-
-        # Block 3 is both a block and water.
-        expected_classes = (test_importexport.Block, test_importexport.Water)
-        loaded_classes_for_object = (object[3].classes,)
-
-        sub_test_classes(
-            testcase, expected_classes, loaded_classes_for_object, label=label
-        )
-
-    # Test relationships.
-    with testcase.subTest(
-        msg=f"{str(label)}"
-        "Checks the loaded relationships between CUDS "
-        "objects."
-    ):
-        for i in range(1, 4):
-            cuds = object[i]
-            neighbor = cuds.get(rel=test_importexport.isLeftOf).one()
-            testcase.assertEqual(neighbor, object[i + 1])
-            neighbor = cuds.get(rel=test_importexport.isNextTo).one()
-            testcase.assertEqual(neighbor, object[i + 1])
-
-
-def sub_test_classes(
-    testcase, expected_classes, loaded_classes_for_object, label=None
-):
-    """Compares items on a tuple of expected classes with loaded classes.
-
-    Args:
-        testcase (unittest.TestCase): the test case where this function is
-            being called.
-        expected_classes (Tuple[class, ...]): A tuple wit the expected
-            classes, in any ordering.
-        loaded_classes_for_object (Tuple[Iterable[class, ...]]): Each
-            element of the tuple is an iterable representing an ontology
-            entity, and each iterable yields the ontology classes of such
-            entity.
-        label(str): a label for the subtests (for example 'import' or
-            'export'). Makes distinguishing the different integrity checks
-            done during a test easier.
-    """
-    if label:
-        label = f"({str(label)}) "
-    else:
-        label = ""
-
-    # Test equality of classes (hashes).
-    expected_names = tuple(cls.__str__() for cls in expected_classes)
-    with testcase.subTest(
-        msg=f"{label}"
-        f"Testing that the classes of the individuals "
-        f'({", ".join(expected_names)}) '
-        f"coincide with the expectation (by hash)."
-    ):
-        for loaded_classes in loaded_classes_for_object:
-            testcase.assertSetEqual(set(expected_classes), set(loaded_classes))
+        # Test equality of classes (hashes).
+        expected_names = tuple(cls.__str__() for cls in expected_classes)
+        with self.subTest(
+            msg=f"{label}"
+            f"Testing that the classes of the individuals "
+            f'({", ".join(expected_names)}) '
+            f"coincide with the expectation (by hash)."
+        ):
+            for loaded_classes in loaded_classes_for_object:
+                self.assertSetEqual(set(expected_classes), set(loaded_classes))
 
 
 if __name__ == "__main__":

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -39,13 +39,13 @@ class TestWrapper(unittest.TestCase):
         """
         ontology = Session(identifier="test_tbox", ontology=True)
         ontology.load_parser(OntologyParser.get_parser("city"))
-        cls.prev_default_ontology = Session.ontology
-        Session.ontology = ontology
+        cls.prev_default_ontology = Session.default_ontology
+        Session.default_ontology = ontology
 
     @classmethod
     def tearDownClass(cls):
         """Restore the previous default TBox."""
-        Session.ontology = cls.prev_default_ontology
+        Session.default_ontology = cls.prev_default_ontology
 
     def tearDown(self) -> None:
         """Remove the database file."""
@@ -171,13 +171,13 @@ class TestDataspaceWrapper(unittest.TestCase):
         """
         ontology = Session(identifier="test_tbox", ontology=True)
         ontology.load_parser(OntologyParser.get_parser("city"))
-        cls.prev_default_ontology = Session.ontology
-        Session.ontology = ontology
+        cls.prev_default_ontology = Session.default_ontology
+        Session.default_ontology = ontology
 
     @classmethod
     def tearDownClass(cls):
         """Restore the previous default TBox."""
-        Session.ontology = cls.prev_default_ontology
+        Session.default_ontology = cls.prev_default_ontology
 
     def setUp(self) -> None:
         """Create a temporary directory for files."""
@@ -351,13 +351,13 @@ class TestRemoteSQLite(unittest.TestCase):
         """
         ontology = Session(identifier="test_tbox", ontology=True)
         ontology.load_parser(OntologyParser.get_parser("city"))
-        cls.prev_default_ontology = Session.ontology
-        Session.ontology = ontology
+        cls.prev_default_ontology = Session.default_ontology
+        Session.default_ontology = ontology
 
     @classmethod
     def tearDownClass(cls):
         """Restore the previous default TBox."""
-        Session.ontology = cls.prev_default_ontology
+        Session.default_ontology = cls.prev_default_ontology
 
     def setUp(self) -> None:
         """Start the InterfaceServer for a new test."""


### PR DESCRIPTION
* Update bundled ontology versions and requirements.

* Remove no longer used keys from bundled ontology files.

* Bundle `emmo-datamodel.yml` ontology file.

* Bundle `prov.yml` ontology file.

* Remove active and default relationships.

* Remove reference by label keword.

* Pico usable as a Python module.

* Dependency resolution for pico, automatic installation of bundled dependencies.

* Facelift for pico code.

* Tests for pico.
