### PR TITLE
Patch DCTERMS when parsing RDF files

### DIFF
--- a/simphony_osp/ontology/parser/owl/parser.py
+++ b/simphony_osp/ontology/parser/owl/parser.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional, Set, Tuple
 
 import requests
 import yaml
-from rdflib import Graph, URIRef
+from rdflib import RDF, RDFS, Graph, URIRef
 from rdflib.util import guess_format
 
 import simphony_osp.ontology.parser.owl.keywords as keywords
@@ -225,4 +225,28 @@ class OWLParser(OntologyParser):
         graph = Graph()
         graph.parse(file_like, format=file_format)
         file_like.close()
+
+        # Patch DCTERMS, which defines http://purl.org/dc/terms/Agent
+        # both as a class and as an instance of
+        # http://purl.org/dc/terms/AgentClass
+        if (
+            URIRef("http://purl.org/dc/terms/"),
+            URIRef("http://purl.org/dc/terms/modified"),
+            None,
+        ) in graph:
+            graph.remove(
+                (
+                    URIRef("http://purl.org/dc/terms/Agent"),
+                    RDF.type,
+                    URIRef("http://purl.org/dc/terms/AgentClass"),
+                )
+            )
+            graph.add(
+                (
+                    URIRef("http://purl.org/dc/terms/Agent"),
+                    RDFS.subClassOf,
+                    URIRef("http://purl.org/dc/terms/AgentClass"),
+                )
+            )
+
         return graph

--- a/simphony_osp/ontology/utils.py
+++ b/simphony_osp/ontology/utils.py
@@ -391,9 +391,9 @@ def _compute_mappings() -> Tuple[Dict[Any, Any], Dict[Any, Any]]:
 
 
 def compatible_classes(type_, identifier):
-    """Given a pair of a RDF type and an identifier get a Python class.
+    """Given a pair of an RDF type and an identifier get a Python class.
 
-    Given a pair of a RDF type and an identifier, the compatible Python
+    Given a pair of an RDF type and an identifier, the compatible Python
     classes are computed. In fact, for the latter only the type of
     identifier matters.
     """


### PR DESCRIPTION
DCTERMS defines http://purl.org/dc/terms/Agent both as a class and as an instance of http://purl.org/dc/terms/AgentClass

The RDF file is patched to change the instance definition to a subclass relationship.