### PR TITLE
Possibility to import and export triples with predicates which are object properties and point to IRIs that do not belong to any class or belong to a class that is not defined on the ontology

### DIFF
--- a/simphony_osp/ontology/individual.py
+++ b/simphony_osp/ontology/individual.py
@@ -427,9 +427,9 @@ class RelationshipSet(ObjectSet):
                     )
                 except KeyError:
                     logger.warning(
-                        f'Ignoring identifier {identifier}, which does not '
-                        f'match an ontology individual belonging to a class in'
-                        f'the ontology.'
+                        f"Ignoring identifier {identifier}, which does not "
+                        f"match an ontology individual belonging to a class in"
+                        f"the ontology."
                     )
 
     def __contains__(self, item: OntologyIndividual) -> bool:

--- a/simphony_osp/ontology/individual.py
+++ b/simphony_osp/ontology/individual.py
@@ -420,12 +420,17 @@ class RelationshipSet(ObjectSet):
                 for identifier in identifiers
             )
         else:
-            yield from (
-                self._individual.session.from_identifier_typed(
-                    identifier, typing=OntologyIndividual
-                )
-                for identifier in connected
-            )
+            for identifier in connected:
+                try:
+                    yield self._individual.session.from_identifier_typed(
+                        identifier, typing=OntologyIndividual
+                    )
+                except KeyError:
+                    logger.warning(
+                        f'Ignoring identifier {identifier}, which does not '
+                        f'match an ontology individual belonging to a class in'
+                        f'the ontology.'
+                    )
 
     def __contains__(self, item: OntologyIndividual) -> bool:
         """Check if an individual is connected via the relationship."""

--- a/simphony_osp/session/session.py
+++ b/simphony_osp/session/session.py
@@ -774,6 +774,7 @@ class Session(Environment):
         *individuals: Union[OntologyIndividual, Iterable[OntologyIndividual]],
         merge: bool = False,
         exists_ok: bool = False,
+        all_triples: bool = True,
     ) -> Union[OntologyIndividual, FrozenSet[OntologyIndividual]]:
         """Copies the ontology entities to the session."""
         # Unpack iterables
@@ -833,7 +834,8 @@ class Session(Environment):
             for s, p, o in individual.session.graph.triples(
                 (individual.identifier, None, None)
             )
-            if (p == RDF.type or isinstance(o, Literal) or o in identifiers)
+            if (all_triples or p == RDF.type
+                or isinstance(o, Literal) or o in identifiers)
         )
         if not merge:
             """Replace previous individuals if merge is False."""

--- a/simphony_osp/session/session.py
+++ b/simphony_osp/session/session.py
@@ -834,8 +834,12 @@ class Session(Environment):
             for s, p, o in individual.session.graph.triples(
                 (individual.identifier, None, None)
             )
-            if (all_triples or p == RDF.type
-                or isinstance(o, Literal) or o in identifiers)
+            if (
+                all_triples
+                or p == RDF.type
+                or isinstance(o, Literal)
+                or o in identifiers
+            )
         )
         if not merge:
             """Replace previous individuals if merge is False."""

--- a/simphony_osp/session/session.py
+++ b/simphony_osp/session/session.py
@@ -774,7 +774,7 @@ class Session(Environment):
         *individuals: Union[OntologyIndividual, Iterable[OntologyIndividual]],
         merge: bool = False,
         exists_ok: bool = False,
-        all_triples: bool = True,
+        all_triples: bool = False,
     ) -> Union[OntologyIndividual, FrozenSet[OntologyIndividual]]:
         """Copies the ontology entities to the session."""
         # Unpack iterables

--- a/simphony_osp/tools/import_export.py
+++ b/simphony_osp/tools/import_export.py
@@ -25,6 +25,7 @@ def import_file(
     path_or_filelike: Union[str, TextIO, dict, List[dict]],
     session: Optional[Session] = None,
     format: str = None,
+    all_triples: bool = False,
 ) -> Union[OntologyIndividual, Set[OntologyIndividual]]:
     """Imports ontology individuals from a file and load them into a session.
 
@@ -47,6 +48,13 @@ def import_file(
             If no format is specified, then it will be guessed. Note that in
             some specific cases, the guess may be wrong. In such cases, try
             again specifying the format.
+        all_triples: When an RDF triple has an ontology relationship as
+            predicate, SimPhoNy checks that both the subject and the object
+            of such triple refer to a valid ontology individual, that is, that
+            an additional triple defining their types exist. When this is not
+            the case, SimPhoNy omits the triple. In some use cases, importing
+            those triples may be necessary. Change the value of this argument
+            to `True` to import them.
 
     Returns:
         A set with the imported ontology individuals. If an individual was
@@ -127,7 +135,10 @@ def import_file(
         for individual in buffer_session
         if isinstance(individual, OntologyIndividual)
     )
-    session.add(individuals, exists_ok=True, merge=False)
+    session.add(individuals,
+                exists_ok=True,
+                merge=False,
+                all_triples=all_triples)
 
     main = next(
         iter(
@@ -157,6 +168,7 @@ def export_file(
     file: Optional[Union[str, TextIO]] = None,
     main: Optional[Union[str, Identifier, OntologyIndividual]] = None,
     format: str = "text/turtle",
+    all_triples: bool = False,
 ) -> Union[str, None]:
     """Exports ontology individuals to a variety of formats.
 
@@ -174,6 +186,14 @@ def export_file(
         main: the identifier of an ontology individual to be marked as the
             "main" individual using the SimPhoNy ontology.
         format: the target format. Defaults to triples in turtle syntax.
+        all_triples: When an RDF triple has an ontology relationship as
+            predicate, SimPhoNy checks that both the subject and the object
+            of such triple refer to a valid ontology individual, that is, that
+            an additional triple defining their types exist. When this is not
+            the case, SimPhoNy omits the triple (unless the whole session is
+            being exported). In some use cases, exporting those triples may be
+            necessary. Change the value of this argument to `True` to export
+            them.
 
     Returns:
         The contents of the exported file as a string (if no `file` argument
@@ -246,7 +266,7 @@ def export_file(
         )
 
         # Add individuals and main individual triple
-        buffer_session.add(individuals_or_session)
+        buffer_session.add(individuals_or_session, all_triples=all_triples)
         if main:
             buffer_session.graph.add(main)
 

--- a/simphony_osp/tools/import_export.py
+++ b/simphony_osp/tools/import_export.py
@@ -135,10 +135,9 @@ def import_file(
         for individual in buffer_session
         if isinstance(individual, OntologyIndividual)
     )
-    session.add(individuals,
-                exists_ok=True,
-                merge=False,
-                all_triples=all_triples)
+    session.add(
+        individuals, exists_ok=True, merge=False, all_triples=all_triples
+    )
 
     main = next(
         iter(


### PR DESCRIPTION
When using the `import_file` and `export_file` methods, if an RDF triple has an ontology relationship as predicate, SimPhoNy checks that both the subject and the object of such triple refer to a valid ontology individual, that is, that an additional triple defining their types exist. When this is not the case, SimPhoNy omits the triple (on export, unless the whole session is being exported). In some use cases, importing and exporting those triples may be needed. This PR adds an additional `all_triples` argument to both methods to enable that. In addition, also an argument `all_triples` has been added to the `add` method of the `Session` class so that this behaviour is also possible when copying individuals between sessions.