### PR TITLE
Use BFS in `find` function and variants 

### DIFF
--- a/simphony_osp/tools/search.py
+++ b/simphony_osp/tools/search.py
@@ -114,10 +114,14 @@ def _iter(
         yield root
 
     if current_depth < max_depth:
-        for sub in chain(
+        # Originally, this function was using DFS (no `list`), but it is
+        # incompatible with the caching mechanism. See issue #820.
+        # TODO: Fix
+        #  [issue #820](https://github.com/simphony/simphony-osp/issues/820).
+        for sub in list(chain(
             *(root.iter(rel=r) for r in rel),
             *(root.annotations_iter(rel=r) for r in annotation)
-        ):
+        )):
             if sub.uid not in visited:
                 yield from _iter(
                     criterion=criterion,

--- a/simphony_osp/tools/search.py
+++ b/simphony_osp/tools/search.py
@@ -72,7 +72,13 @@ def find(
         annotation = set()
     annotation = frozenset(annotation)
 
-    result = _iter(criterion, root, rel, annotation, max_depth)
+    result = iter(())
+    if criterion(root):
+        result = chain(result, (root, ))
+    result = chain(
+        result,
+        _iter(criterion, root, rel, annotation, max_depth)
+    )
     if not find_all:
         result = next(result, None)
 
@@ -110,8 +116,6 @@ def _iter(
     """
     visited = visited or set()
     visited.add(root.uid)
-    if criterion(root):
-        yield root
 
     if current_depth < max_depth:
         # Originally, this function was using DFS (no `list`), but it is
@@ -127,7 +131,10 @@ def _iter(
             for child in children
             if child.uid not in visited
         )
-        yield from children
+        yield from (
+            child
+            for child in children if criterion(child)
+        )
         for sub in children:
             yield from _iter(
                 criterion=criterion,

--- a/simphony_osp/tools/search.py
+++ b/simphony_osp/tools/search.py
@@ -122,11 +122,7 @@ def _iter(
             *(root.iter(rel=r) for r in rel),
             *(root.annotations_iter(rel=r) for r in annotation)
         )
-        children = set(
-            child
-            for child in children
-            if child.uid not in visited
-        )
+        children = set(child for child in children if child.uid not in visited)
         yield from children
         for sub in children:
             yield from _iter(

--- a/simphony_osp/tools/search.py
+++ b/simphony_osp/tools/search.py
@@ -118,20 +118,26 @@ def _iter(
         # incompatible with the caching mechanism. See issue #820.
         # TODO: Fix
         #  [issue #820](https://github.com/simphony/simphony-osp/issues/820).
-        for sub in list(chain(
+        children = chain(
             *(root.iter(rel=r) for r in rel),
             *(root.annotations_iter(rel=r) for r in annotation)
-        )):
-            if sub.uid not in visited:
-                yield from _iter(
-                    criterion=criterion,
-                    root=sub,
-                    rel=rel,
-                    annotation=annotation,
-                    max_depth=max_depth,
-                    current_depth=current_depth + 1,
-                    visited=visited,
-                )
+        )
+        children = set(
+            child
+            for child in children
+            if child.uid not in visited
+        )
+        yield from children
+        for sub in children:
+            yield from _iter(
+                criterion=criterion,
+                root=sub,
+                rel=rel,
+                annotation=annotation,
+                max_depth=max_depth,
+                current_depth=current_depth + 1,
+                visited=visited,
+            )
 
 
 def find_by_identifier(

--- a/simphony_osp/tools/search.py
+++ b/simphony_osp/tools/search.py
@@ -74,11 +74,8 @@ def find(
 
     result = iter(())
     if criterion(root):
-        result = chain(result, (root, ))
-    result = chain(
-        result,
-        _iter(criterion, root, rel, annotation, max_depth)
-    )
+        result = chain(result, (root,))
+    result = chain(result, _iter(criterion, root, rel, annotation, max_depth))
     if not find_all:
         result = next(result, None)
 
@@ -126,15 +123,8 @@ def _iter(
             *(root.iter(rel=r) for r in rel),
             *(root.annotations_iter(rel=r) for r in annotation)
         )
-        children = set(
-            child
-            for child in children
-            if child.uid not in visited
-        )
-        yield from (
-            child
-            for child in children if criterion(child)
-        )
+        children = set(child for child in children if child.uid not in visited)
+        yield from (child for child in children if criterion(child))
         for sub in children:
             yield from _iter(
                 criterion=criterion,


### PR DESCRIPTION
The `find` function may yield an exception in sessions that use the SimPhoNy cache feature (issue #820). This PR makes it use BFS as a workaround.